### PR TITLE
Fix/prevent hull failures

### DIFF
--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -127,7 +127,16 @@ def test_nonplanar(square_points):
                    [2.72755193, 1.32128906]]))
 def test_reordering_convex(points):
     """Test that vertices can be reordered appropriately."""
-    hull = ConvexHull(points)
+    # Avoid issues from floating point error.
+    eps = 1e-4
+    try:
+        hull = ConvexHull(points)
+    except QhullError:
+        assume(False)
+    else:
+        # Avoid cases where numerical imprecision make tests fail.
+        assume(hull.volume > eps)
+
     verts = points[hull.vertices]
     poly = Polygon(verts)
     assert np.all(poly.vertices[:, :2] == verts)
@@ -140,7 +149,16 @@ def test_reordering_convex(points):
                    [2.72755193, 1.32128906]]))
 def test_convex_area(points):
     """Check the areas of various convex sets."""
-    hull = ConvexHull(points)
+    # Avoid issues from floating point error.
+    eps = 1e-4
+    try:
+        hull = ConvexHull(points)
+    except QhullError:
+        assume(False)
+    else:
+        # Avoid cases where numerical imprecision make tests fail.
+        assume(hull.volume > eps)
+
     verts = points[hull.vertices]
     poly = Polygon(verts)
     assert np.isclose(hull.volume, poly.area)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Always require convex hulls to have a minimal area when running tests.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some of the tests in polygon were still testing convex hulls of nearly affinely dependent points, which have areas near 0. Such calculations can fail the tests due to problems with precision.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/euclid/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/euclid/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/euclid/blob/master/ChangeLog.txt).
