### PR TITLE
Feature/circumsphere from center

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,12 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v0.3.0 - xxxx-xx-xx
+
+### Added
+
+* Calculation of circumsphere from center for convex polyhedra.
+
 ## v0.2.0 - 2020-04-09
 
 ### Added

--- a/coxeter/shape_classes/convex_polyhedron.py
+++ b/coxeter/shape_classes/convex_polyhedron.py
@@ -82,3 +82,13 @@ class ConvexPolyhedron(Polyhedron):
                              "insphere from center is not defined.")
         min_distance = -np.max(distances)
         return center, min_distance
+
+    @property
+    def circumsphere_from_center(self):
+        """The smallest sphere centered at the centroid that contains the
+        convex polyhedron, given by a center and a radius."""
+        center = self.center
+        if not self.is_inside(center):
+            raise ValueError("The centroid is not contained in the shape. The "
+                             "circumsphere from center is not defined.")
+        return center, np.max(np.linalg.norm(self._vertices - center, axis=-1))

--- a/doc/source/credits.rst
+++ b/doc/source/credits.rst
@@ -23,6 +23,7 @@ Vyas Ramasubramani - **Creator and former lead developer**
 * Add ability to calculate minimum bounding sphere/circle for polyhedra/polygons.
 * Implemented ConvexPolygon class.
 * Added ReadTheDocs support.
+* Added circumsphere from center calculation for convex polyhedra.
 
 Bryan VanSaders - **Original maintainer of euclid package**
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Add calculation of smallest sphere centered at the centroid of a polyhedron that contains that polyhedron. 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
For applications in particle simulations, this calculation is more frequently what is desired than the proper circumsphere calculation (a sphere that touches all vertices of a shape, with no centering constraint).

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/euclid/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/euclid/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/euclid/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/euclid/blob/master/doc/source/credits.rst).
