### PR TITLE
Feature/set circle area

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@ and this project adheres to
 * Interoperability with the GSD shape specification.
 * Shape families and stored data for well-known families.
 * Extensive style checking using black, isort, and various other flake8 plugins.
+* Make Circle area settable.
 
 ### Changed
 * Inertia tensors for polyhedra and moments of inertia for polygons are calculated in global coordinates rather than the body frame.

--- a/coxeter/shape_classes/circle.py
+++ b/coxeter/shape_classes/circle.py
@@ -48,6 +48,10 @@ class Circle(Shape2D):
         """float: Get the area of the circle."""
         return np.pi * self.radius ** 2
 
+    @area.setter
+    def area(self, value):
+        self._radius = np.sqrt(value / np.pi)
+
     @property
     def eccentricity(self):
         """float: Get the eccentricity of the circle.

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -3,6 +3,7 @@ import pytest
 from hypothesis import given
 from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
+from pytest import approx
 
 from coxeter.shape_classes.circle import Circle
 
@@ -20,6 +21,15 @@ def test_area(r):
     circle = Circle(1)
     circle.radius = r
     assert circle.area == np.pi * r ** 2
+
+
+@given(floats(0.1, 1000))
+def test_set_area(area):
+    """Test setting the area."""
+    circle = Circle(1)
+    circle.area = area
+    assert circle.area == approx(area)
+    assert circle.radius == approx((area / np.pi) ** 0.5)
 
 
 @given(floats(0.1, 1000))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Make circle area a settable property.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The current usage of abstract methods in the base class is not actually enforcing implementation of setters since replacing the getter creates a new property instance that no longer has this decorator attached. This needs to be addressed more globally, but at the moment I need a settable area for circles so I'm adding this feature.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/euclid/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/euclid/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/euclid/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/euclid/blob/master/doc/source/credits.rst).
