### PR TITLE
Feature/diagonalize inertia

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ and this project adheres to
 * Shape families and stored data for well-known families.
 * Extensive style checking using black, isort, and various other flake8 plugins.
 * Make Circle area settable.
+* 3D shapes can be oriented by their principal axes.
 
 ### Changed
 * Inertia tensors for polyhedra and moments of inertia for polygons are calculated in global coordinates rather than the body frame.

--- a/coxeter/shape_classes/base_classes.py
+++ b/coxeter/shape_classes/base_classes.py
@@ -8,8 +8,6 @@ parts of the code base that either require or return shapes.
 
 from abc import ABC, abstractmethod
 
-import numpy as np
-
 
 class Shape(ABC):
     """An abstract representation of a shape in N dimensions."""
@@ -75,13 +73,3 @@ class Shape3D(Shape):
     def inertia_tensor(self):
         """:math:`(3, 3)` :class:`numpy.ndarray`: Get the inertia tensor."""
         pass
-
-    def diagonalize_inertia(self):
-        """Orient the shape along its principal axes.
-
-        The principal axes of a shape are defined by the eigenvectors of the inertia
-        tensor. This method computes the inertia tensor of the shape, diagonalizes it,
-        and then rotates the shape by the corresponding orthogonal transformation.
-        """
-        principal_moments, principal_axes = np.linalg.eigh(self.inertia_tensor)
-        self._vertices = np.dot(self._vertices, principal_axes)

--- a/coxeter/shape_classes/base_classes.py
+++ b/coxeter/shape_classes/base_classes.py
@@ -8,6 +8,8 @@ parts of the code base that either require or return shapes.
 
 from abc import ABC, abstractmethod
 
+import numpy as np
+
 
 class Shape(ABC):
     """An abstract representation of a shape in N dimensions."""
@@ -68,3 +70,18 @@ class Shape3D(Shape):
     @abstractmethod
     def surface_area(self, value):
         pass
+
+    @abstractmethod
+    def inertia_tensor(self):
+        """:math:`(3, 3)` :class:`numpy.ndarray`: Get the inertia tensor."""
+        pass
+
+    def diagonalize_inertia(self):
+        """Orient the shape along its principal axes.
+
+        The principal axes of a shape are defined by the eigenvectors of the inertia
+        tensor. This method computes the inertia tensor of the shape, diagonalizes it,
+        and then rotates the shape by the corresponding orthogonal transformation.
+        """
+        principal_moments, principal_axes = np.linalg.eigh(self.inertia_tensor)
+        self._vertices = np.dot(self._vertices, principal_axes)

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -200,3 +200,11 @@ class ConvexSpheropolyhedron(Shape3D):
                 in_sphero_shape[point_id] = check_face(point_id, face_id)
 
         return in_polyhedron | in_sphero_shape
+
+    def inertia_tensor(self):
+        """:math:`(3, 3)` :class:`numpy.ndarray`: Get the inertia tensor.
+
+        Warnings:
+            This calculation is not implemented for :class:`~.ConvexSpheropolyhedron`.
+        """
+        raise NotImplementedError

--- a/coxeter/shape_classes/polyhedron.py
+++ b/coxeter/shape_classes/polyhedron.py
@@ -513,3 +513,13 @@ class Polyhedron(Shape3D):
             shift = (np.max(self.vertices[:, 2]) - np.min(self.vertices[:, 2])) * 0.025
             for i, vert in enumerate(self.vertices):
                 ax.text(vert[0], vert[1], vert[2] + shift, "{}".format(i), fontsize=10)
+
+    def diagonalize_inertia(self):
+        """Orient the shape along its principal axes.
+
+        The principal axes of a shape are defined by the eigenvectors of the inertia
+        tensor. This method computes the inertia tensor of the shape, diagonalizes it,
+        and then rotates the shape by the corresponding orthogonal transformation.
+        """
+        principal_moments, principal_axes = np.linalg.eigh(self.inertia_tensor)
+        self._vertices = np.dot(self._vertices, principal_axes)

--- a/doc/source/credits.rst
+++ b/doc/source/credits.rst
@@ -28,6 +28,7 @@ Vyas Ramasubramani - **Creator and former lead developer**
 * Define proper inertia tensor calculations and transformations for polygons and polyhedra.
 * Added interoperability with the GSD shape specification.
 * Developed shape families and all associated shape repository APIs.
+* Add ability to diagonlize the inertia tensors of shapes.
 
 Bryan VanSaders - **Original maintainer of euclid package**
 

--- a/tests/test_polyhedron.py
+++ b/tests/test_polyhedron.py
@@ -455,3 +455,19 @@ def test_translate_inertia(translation):
 
     assert np.allclose(mc_tensor, translated_inertia, atol=1e-2, rtol=1e-2)
     assert np.allclose(mc_tensor, translated_shape.inertia_tensor, atol=1e-2, rtol=1e-2)
+
+
+@given(arrays(np.float64, (5, 3), elements=floats(-10, 10, width=64), unique=True))
+def test_diagonalize_inertia(points):
+    """Test that we can orient a polyhedron along its principal axes."""
+    hull = get_valid_hull(points)
+    assume(hull)
+
+    poly = polyhedron_from_hull(points[hull.vertices])
+    assume(poly)
+
+    it = poly.inertia_tensor
+    if not np.allclose(np.diag(np.diag(it)), it):
+        poly.diagonalize_inertia()
+        it = poly.inertia_tensor
+        assert np.allclose(np.diag(np.diag(it)), it)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Add ability to polyhedra shapes to diagonalize their inertia tensors.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
HOOMD-blue assumes that we provide the principal components of the inertia tensor.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/euclid/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/euclid/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/euclid/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/euclid/blob/master/doc/source/credits.rst).
