### PR TITLE
Fix/is inside ellipsoids

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ and this project adheres to
 * Polygons moment of inertia calculation.
 * Interoperability with the GSD shape specification.
 * Shape families and stored data for well-known families.
+* All shapes can be centered anywhere in 3D Euclidean space.
 * Extensive style checking using black, isort, and various other flake8 plugins.
 * Make Circle area settable.
 * 3D shapes can be oriented by their principal axes.

--- a/coxeter/shape_classes/ellipsoid.py
+++ b/coxeter/shape_classes/ellipsoid.py
@@ -127,6 +127,6 @@ class Ellipsoid(Shape3D):
                 Boolean array indicating which points are contained in the
                 ellipsoid.
         """
-        points = np.atleast_2d(points)
+        points = np.atleast_2d(points) - self.center
         scale = np.array([self.a, self.b, self.c])
         return np.linalg.norm(points / scale, axis=-1) <= 1

--- a/coxeter/shape_classes/sphere.py
+++ b/coxeter/shape_classes/sphere.py
@@ -87,5 +87,5 @@ class Sphere(Shape3D):
                 Boolean array indicating which points are contained in the
                 sphere.
         """
-        points = np.atleast_2d(points)
+        points = np.atleast_2d(points) - self.center
         return np.linalg.norm(points, axis=-1) <= self.radius

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -82,15 +82,21 @@ def test_inertia_tensor(a, b, c, center):
     np.testing.assert_allclose(ellipsoid.inertia_tensor, expected)
 
 
-@given(floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000))
-def test_is_inside(a, b, c):
-    ellipsoid = Ellipsoid(a, b, c)
-    points_inside = np.array(
+@given(
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_is_inside(a, b, c, center):
+    ellipsoid = Ellipsoid(a, b, c, center)
+    # Add a small fudge factor to avoid floating point error.
+    points_inside = (1 - 1e-6) * np.array(
         [[a, 0, 0], [-a, 0, 0], [0, b, 0], [0, -b, 0], [0, 0, c], [0, 0, -c]]
     )
-    assert all(ellipsoid.is_inside(points_inside))
-    assert all(ellipsoid.is_inside(points_inside / 2))
-    assert not any(ellipsoid.is_inside(points_inside * 1.1))
+    assert all(ellipsoid.is_inside(points_inside + center))
+    assert all(ellipsoid.is_inside(points_inside / 2 + center))
+    assert not any(ellipsoid.is_inside(points_inside * 1.1 + center))
 
 
 def test_center():

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -44,10 +44,13 @@ def test_inertia_tensor(r, center):
     np.testing.assert_allclose(sphere.inertia_tensor, expected)
 
 
-@given(floats(0.1, 10))
-def test_is_inside(r):
-    sphere = Sphere(1)
-    assert sphere.is_inside([r, 0, 0]).squeeze() == (r <= 1)
+@given(
+    floats(0.1, 10),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_is_inside(radius, center):
+    sphere = Sphere(1, center)
+    assert sphere.is_inside([radius, 0, 0] + center).squeeze() == (radius <= 1)
 
 
 def test_center():


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Checks for points contained in spheres or ellipsoids work correctly when the shapes are not centered at the origin.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The addition of centers #72 was not propagated to these methods, which need to shift points to the appropriate centering before checking if they are inside the shape.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/euclid/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/euclid/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/euclid/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/euclid/blob/master/doc/source/credits.rst).
