### PR TITLE
Feature/return circles spheres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run:
           name: style-check
           command: |
-            python -m pip install --user -U flake8 flake8-black flake8-bugbear flake8-docstrings flake8-rst-docstrings pep8-naming flake8-isort
+            python -m pip install --progress-bar off --user -U flake8 flake8-black flake8-bugbear flake8-docstrings flake8-rst-docstrings pep8-naming flake8-isort
             python -m flake8 --show-source coxeter/
             # Ignore isort errors in tests that are due to ambiguity over whether or not coxeter is third party.
             python -m flake8 --extend-ignore=I001,I004 --show-source tests/
@@ -36,7 +36,7 @@ jobs:
           name: Run tests
           command: |
             python --version
-            python -m pip install .[test] --user
+            python -m pip install .[test] --progress-bar off --user
             python -c "import numpy; print('numpy', numpy.__version__)"
             python -c "import scipy; print('scipy', scipy.__version__)"
             pytest
@@ -63,15 +63,15 @@ jobs:
       - run:
           name: Deploy dist and wheels
           command: |
-            python -m pip install --user -U flake8 flake8-black flake8-bugbear flake8-docstrings flake8-rst-docstrings pep8-naming flake8-isort
-            python -m pip install .[test] --user
+            python -m pip install --progress-bar off --user -U flake8 flake8-black flake8-bugbear flake8-docstrings flake8-rst-docstrings pep8-naming flake8-isort
+            python -m pip install .[test] --progress-bar off --user
             python -m flake8 --show-source coxeter/
             # Ignore isort errors in tests that are due to ambiguity over whether or not coxeter is third party.
             python -m flake8 --extend-ignore=I001,I004 --show-source tests/
             python -m pytest
             python --version
             python -m pip --version
-            python -m pip install --user -U twine wheel setuptools
+            python -m pip install --progress-bar off --user -U twine wheel setuptools
             python -m twine --version
             python -m wheel version
             python setup.py sdist

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,7 @@ and this project adheres to
 ### Changed
 * Inertia tensors for polyhedra and moments of inertia for polygons are calculated in global coordinates rather than the body frame.
 * Modified testing of convex hulls to generate points on ellipsoids to avoid degenerate simplices.
+* All insphere, circumsphere, and bounding sphere calculations now return the appropriate classes instead of tuples.
 
 ## v0.2.0 - 2020-04-09
 

--- a/coxeter/shape_classes/convex_polygon.py
+++ b/coxeter/shape_classes/convex_polygon.py
@@ -3,8 +3,8 @@
 import numpy as np
 from scipy.spatial import ConvexHull
 
-from .polygon import Polygon, _align_points_by_normal
 from .circle import Circle
+from .polygon import Polygon, _align_points_by_normal
 
 
 def _is_convex(vertices, normal):

--- a/coxeter/shape_classes/convex_polygon.py
+++ b/coxeter/shape_classes/convex_polygon.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.spatial import ConvexHull
 
 from .polygon import Polygon, _align_points_by_normal
+from . import Circle
 
 
 def _is_convex(vertices, normal):
@@ -72,7 +73,7 @@ class ConvexPolygon(Polygon):
 
     @property
     def incircle_from_center(self):
-        """Get the largest inscribed circle centered at the centroid.
+        """`~.Circle`: Get the largest inscribed circle centered at the centroid.
 
         The requirement that the circle be centered at the centroid of the
         shape distinguishes this circle from most typical incircle
@@ -87,4 +88,4 @@ class ConvexPolygon(Polygon):
         distances = np.linalg.norm(np.cross(points, deltas), axis=-1)
 
         radius = np.min(distances)
-        return self.center, radius
+        return Circle(self.center, radius)

--- a/coxeter/shape_classes/convex_polygon.py
+++ b/coxeter/shape_classes/convex_polygon.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy.spatial import ConvexHull
 
 from .polygon import Polygon, _align_points_by_normal
-from . import Circle
+from .circle import Circle
 
 
 def _is_convex(vertices, normal):
@@ -88,4 +88,4 @@ class ConvexPolygon(Polygon):
         distances = np.linalg.norm(np.cross(points, deltas), axis=-1)
 
         radius = np.min(distances)
-        return Circle(self.center, radius)
+        return Circle(radius, self.center)

--- a/coxeter/shape_classes/convex_polyhedron.py
+++ b/coxeter/shape_classes/convex_polyhedron.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.spatial import ConvexHull
 
 from .polyhedron import Polyhedron
+from . import Sphere
 
 
 class ConvexPolyhedron(Polyhedron):
@@ -83,7 +84,7 @@ class ConvexPolyhedron(Polyhedron):
 
     @property
     def insphere_from_center(self):
-        """Get the largest inscribed sphere centered at the centroid.
+        """:class:`~.Sphere`: Get the largest inscribed sphere centered at the centroid.
 
         The requirement that the sphere be centered at the centroid of the
         shape distinguishes this sphere from most typical insphere
@@ -97,11 +98,11 @@ class ConvexPolyhedron(Polyhedron):
                 "insphere from center is not defined."
             )
         min_distance = -np.max(distances)
-        return center, min_distance
+        return Sphere(center, min_distance)
 
     @property
     def circumsphere_from_center(self):
-        """Get the smallest circumscribed sphere centered at the centroid.
+        """:class:`~.Sphere`: Get the smallest circumscribed sphere centered at the centroid.
 
         The requirement that the sphere be centered at the centroid of the
         shape distinguishes this sphere from most typical circumsphere

--- a/coxeter/shape_classes/convex_polyhedron.py
+++ b/coxeter/shape_classes/convex_polyhedron.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy.spatial import ConvexHull
 
 from .polyhedron import Polyhedron
-from . import Sphere
+from .sphere import Sphere
 
 
 class ConvexPolyhedron(Polyhedron):
@@ -98,7 +98,7 @@ class ConvexPolyhedron(Polyhedron):
                 "insphere from center is not defined."
             )
         min_distance = -np.max(distances)
-        return Sphere(center, min_distance)
+        return Sphere(min_distance, center)
 
     @property
     def circumsphere_from_center(self):
@@ -114,4 +114,4 @@ class ConvexPolyhedron(Polyhedron):
                 "The centroid is not contained in the shape. The "
                 "circumsphere from center is not defined."
             )
-        return center, np.max(np.linalg.norm(self._vertices - center, axis=-1))
+        return Sphere(np.max(np.linalg.norm(self._vertices - center, axis=-1)), center)

--- a/coxeter/shape_classes/polygon.py
+++ b/coxeter/shape_classes/polygon.py
@@ -7,6 +7,7 @@ from ..bentley_ottman import poly_point_isect
 from ..polytri import polytri
 from .base_classes import Shape2D
 from .utils import rotate_order2_tensor, translate_inertia_tensor
+from .circle import Circle
 
 try:
     import miniball
@@ -460,11 +461,11 @@ class Polygon(Shape2D):
         # The center must be rotated back to undo any rotation.
         center = rowan.rotate(rowan.conjugate(current_rotation), center)
 
-        return center, np.sqrt(r2)
+        return Circle(np.sqrt(r2), center)
 
     @property
     def circumcircle(self):
-        """float: Get the polygon's circumcircle."""
+        """:class:`~.Circle`: Get the polygon's circumcircle."""
         # Solves a linear system of equations to find a point equidistant from
         # all the vertices if it exists. Since the polygon is embedded in 3D,
         # we must constrain our solutions to the plane of the polygon.
@@ -478,4 +479,4 @@ class Polygon(Shape2D):
         if len(self.vertices) > 3 and not np.isclose(resids, 0):
             raise RuntimeError("No circumcircle for this polygon.")
 
-        return x + self.vertices[0], np.linalg.norm(x)
+        return Circle(np.linalg.norm(x), x + self.vertices[0])

--- a/coxeter/shape_classes/polygon.py
+++ b/coxeter/shape_classes/polygon.py
@@ -6,8 +6,8 @@ import rowan
 from ..bentley_ottman import poly_point_isect
 from ..polytri import polytri
 from .base_classes import Shape2D
-from .utils import rotate_order2_tensor, translate_inertia_tensor
 from .circle import Circle
+from .utils import rotate_order2_tensor, translate_inertia_tensor
 
 try:
     import miniball

--- a/coxeter/shape_classes/polyhedron.py
+++ b/coxeter/shape_classes/polyhedron.py
@@ -8,7 +8,7 @@ from .base_classes import Shape3D
 from .convex_polygon import ConvexPolygon, _is_convex
 from .polygon import Polygon, _is_simple
 from .utils import translate_inertia_tensor
-from . import Sphere
+from .sphere import Sphere
 
 try:
     import miniball
@@ -416,7 +416,7 @@ class Polyhedron(Shape3D):
 
     @property
     def bounding_sphere(self):
-        """tuple[float, float]: Get the center and radius of the bounding sphere."""  # noqa: E501
+        """:class:`~.Sphere`: Get the center and radius of the bounding sphere."""
         if not MINIBALL:
             raise ImportError(
                 "The miniball module must be installed. It can "
@@ -446,7 +446,7 @@ class Polyhedron(Shape3D):
         # The center must be rotated back to undo any rotation.
         center = rowan.rotate(rowan.conjugate(current_rotation), center)
 
-        return center, np.sqrt(r2)
+        return Sphere(np.sqrt(r2), center)
 
     @property
     def circumsphere(self):
@@ -457,7 +457,7 @@ class Polyhedron(Shape3D):
         if len(self.vertices) > 4 and not np.isclose(resids, 0):
             raise RuntimeError("No circumsphere for this polyhedron.")
 
-        return Sphere(x + self.vertices[0], np.linalg.norm(x))
+        return Sphere(np.linalg.norm(x), x + self.vertices[0])
 
     @property
     def iq(self):

--- a/coxeter/shape_classes/polyhedron.py
+++ b/coxeter/shape_classes/polyhedron.py
@@ -7,8 +7,8 @@ from scipy.sparse.csgraph import connected_components
 from .base_classes import Shape3D
 from .convex_polygon import ConvexPolygon, _is_convex
 from .polygon import Polygon, _is_simple
-from .utils import translate_inertia_tensor
 from .sphere import Sphere
+from .utils import translate_inertia_tensor
 
 try:
     import miniball

--- a/coxeter/shape_classes/polyhedron.py
+++ b/coxeter/shape_classes/polyhedron.py
@@ -8,6 +8,7 @@ from .base_classes import Shape3D
 from .convex_polygon import ConvexPolygon, _is_convex
 from .polygon import Polygon, _is_simple
 from .utils import translate_inertia_tensor
+from . import Sphere
 
 try:
     import miniball
@@ -449,14 +450,14 @@ class Polyhedron(Shape3D):
 
     @property
     def circumsphere(self):
-        """float: Get the polyhedron's circumsphere."""
+        """:class:`~.Sphere`: Get the polyhedron's circumsphere."""
         points = self.vertices[1:] - self.vertices[0]
         half_point_lengths = np.sum(points * points, axis=1) / 2
         x, resids, _, _ = np.linalg.lstsq(points, half_point_lengths, None)
         if len(self.vertices) > 4 and not np.isclose(resids, 0):
             raise RuntimeError("No circumsphere for this polyhedron.")
 
-        return x + self.vertices[0], np.linalg.norm(x)
+        return Sphere(x + self.vertices[0], np.linalg.norm(x))
 
     @property
     def iq(self):

--- a/doc/source/credits.rst
+++ b/doc/source/credits.rst
@@ -28,7 +28,9 @@ Vyas Ramasubramani - **Creator and former lead developer**
 * Define proper inertia tensor calculations and transformations for polygons and polyhedra.
 * Added interoperability with the GSD shape specification.
 * Developed shape families and all associated shape repository APIs.
-* Add ability to diagonlize the inertia tensors of shapes.
+* Add ability to diagonalize the inertia tensors of shapes.
+* Defined base classes for all shapes.
+* Standardize usage of Sphere/Circle classes for circum, in, and bounding sphere/circle calculations.
 
 Bryan VanSaders - **Original maintainer of euclid package**
 

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -252,10 +252,10 @@ def test_bounding_circle_radius_regular_polygon():
         rmax = np.max(np.linalg.norm(vertices, axis=-1))
 
         poly = Polygon(vertices)
-        center, radius = poly.bounding_circle
+        circle = poly.bounding_circle
 
-        assert np.isclose(rmax, radius)
-        assert np.allclose(center, 0)
+        assert np.isclose(rmax, circle.radius)
+        assert np.allclose(circle.center, 0)
 
 
 @given(EllipseSurfaceStrategy)
@@ -267,12 +267,12 @@ def test_bounding_circle_radius_random_hull(points):
     # an upper bound on the bounding sphere radius, but need not be the radius
     # because the ball need not be centered at the centroid.
     rmax = np.max(np.linalg.norm(poly.vertices, axis=-1))
-    center, radius = poly.bounding_circle
-    assert radius <= rmax + 1e-6
+    circle = poly.bounding_circle
+    assert circle.radius <= rmax + 1e-6
 
     poly.center = [0, 0, 0]
-    center, radius = poly.bounding_circle
-    assert radius <= rmax + 1e-6
+    circle = poly.bounding_circle
+    assert circle.radius <= rmax + 1e-6
 
 
 @settings(deadline=500)
@@ -291,9 +291,9 @@ def test_bounding_circle_radius_random_hull_rotation(points, rotation):
     rotated_vertices = rowan.rotate(rotation, poly.vertices)
     poly_rotated = Polygon(rotated_vertices)
 
-    _, radius = poly.bounding_circle
-    _, rotated_radius = poly_rotated.bounding_circle
-    assert np.isclose(radius, rotated_radius)
+    circle = poly.bounding_circle
+    rotated_circle = poly_rotated.bounding_circle
+    assert np.isclose(circle.radius, rotated_circle.radius)
 
 
 def test_circumcircle():
@@ -303,13 +303,13 @@ def test_circumcircle():
         rmax = np.max(np.linalg.norm(vertices, axis=-1))
 
         poly = Polygon(vertices)
-        center, radius = poly.circumcircle
+        circle = poly.circumcircle
 
-        assert np.isclose(rmax, radius)
-        assert np.allclose(center, 0)
+        assert np.isclose(rmax, circle.radius)
+        assert np.allclose(circle.center, 0)
 
 
 def test_incircle_from_center(convex_square):
-    center, radius = convex_square.incircle_from_center
-    assert np.all(center == convex_square.center)
-    assert radius == 0.5
+    circle = convex_square.incircle_from_center
+    assert np.all(circle.center == convex_square.center)
+    assert circle.radius == 0.5

--- a/tests/test_polyhedron.py
+++ b/tests/test_polyhedron.py
@@ -321,9 +321,7 @@ def test_circumsphere_from_center():
 
         # Verify that all points outside the circumsphere are also outside the
         # polyhedron.
-        assert not np.any(
-            np.logical_and(points_outside, poly.is_inside(scaled_points))
-        )
+        assert not np.any(np.logical_and(points_outside, poly.is_inside(scaled_points)))
 
     testfun()
 

--- a/tests/test_polyhedron.py
+++ b/tests/test_polyhedron.py
@@ -368,8 +368,6 @@ def test_insphere_from_center_convex_hulls(points, test_points):
     insphere = poly.insphere_from_center
     assert poly.is_inside(insphere.center)
 
-    poly.center = [0, 0, 0]
-    test_points -= np.mean(test_points, axis=0)
     test_points *= insphere.radius * 3
     points_in_sphere = insphere.is_inside(test_points)
     points_in_poly = poly.is_inside(test_points)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Change all insphere, circumsphere, and bounding sphere calculations for polytopes to return the appropriate classes instead of (center, radii) tuples.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves #59.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/euclid/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/euclid/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/euclid/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/euclid/blob/master/doc/source/credits.rst).
