### PR TITLE
Feature/spheropolyhedron circumcircle from center

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,19 @@
 The format is based on `Keep a Changelog <http://keepachangelog.com/en/1.0.0/>`__.
 This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`__.
 
+
+v0.4.0 - xxxx-xx-xx
+-------------------
+
+Added
+~~~~~
+
+- Circumsphere and insphere from center calculations for ConvexSpheropolyhedron.
+
+Fixed
+~~~~~
+- Volume calculation for ConvexSpheropolyhedron includes area of extruded faces in addition to vertices and edges.
+
 v0.3.0 - 2020-06-18
 -------------------
 

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -61,7 +61,7 @@ class ConvexSpheropolyhedron(Shape3D):
     def volume(self):
         """float: The volume."""
         # Compute the volume as the sum of 4 terms:
-        # 1) the volume of the underlying polyhedron.
+        # 1) The volume of the underlying polyhedron.
         # 2) The volume of the spherical caps on the vertices, which sum up to
         #    a single sphere with the spheropolyhedron's rounding radius.
         # 3) The volume of cylindrical wedges along the edges, which are
@@ -95,6 +95,14 @@ class ConvexSpheropolyhedron(Shape3D):
     @property
     def surface_area(self):
         """float: Get the surface area."""
+        # Compute the surface area as the sum of 3 terms:
+        # 1) The (now extruded) surface area of the underlying polyhedron.
+        # 2) The surface are of the spherical vertex caps, which is just the
+        #    surface area of a single sphere with the rounding radius.
+        # 3) The surface area of cylindrical wedges along the edges, which are
+        #    computed using a standard cylinder formula then using the dihedral
+        #    angle of the face to determine what fraction of the cylinder to
+        #    include.
         a_poly = self.polyhedron.surface_area
         a_sphere = 4 * np.pi * self._radius ** 2
         a_cyl = 0

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -208,3 +208,27 @@ class ConvexSpheropolyhedron(Shape3D):
             This calculation is not implemented for :class:`~.ConvexSpheropolyhedron`.
         """
         raise NotImplementedError
+
+    @property
+    def circumsphere_from_center(self):
+        """:class:`~.Sphere`: Get the smallest circumscribed sphere centered at the centroid.
+
+        The requirement that the sphere be centered at the centroid of the
+        shape distinguishes this sphere from most typical circumsphere
+        calculations.
+        """
+        circumsphere = self._polyhedron.circumsphere_from_center
+        circumsphere.radius += self._radius
+        return circumsphere
+
+    @property
+    def insphere_from_center(self):
+        """:class:`~.Sphere`: Get the largest inscribed sphere centered at the centroid.
+
+        The requirement that the sphere be centered at the centroid of the
+        shape distinguishes this sphere from most typical insphere
+        calculations.
+        """
+        insphere = self._polyhedron.insphere_from_center
+        insphere.radius += self._radius
+        return insphere

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -60,9 +60,20 @@ class ConvexSpheropolyhedron(Shape3D):
     @property
     def volume(self):
         """float: The volume."""
+        # Compute the volume as the sum of 4 terms:
+        # 1) the volume of the underlying polyhedron.
+        # 2) The volume of the spherical caps on the vertices, which sum up to
+        #    a single sphere with the spheropolyhedron's rounding radius.
+        # 3) The volume of cylindrical wedges along the edges, which are
+        #    computed using a standard cylinder formula then using the dihedral
+        #    angle of the face to determine what fraction of the cylinder to
+        #    include.
+        # 4) The volume of the extruded faces, which is the surface area of
+        #    each face multiplied by the rounding radius.
         v_poly = self.polyhedron.volume
         v_sphere = (4 / 3) * np.pi * self._radius ** 3
         v_cyl = 0
+        v_face = self.polyhedron.surface_area * self._radius
 
         # For every pair of faces, find the dihedral angle, divide by 2*pi to
         # get the fraction of a cylinder it includes, then multiply by the edge
@@ -74,7 +85,7 @@ class ConvexSpheropolyhedron(Shape3D):
             )
             v_cyl += (np.pi * self.radius ** 2) * (phi / (2 * np.pi)) * edge_length
 
-        return v_poly + v_sphere + v_cyl
+        return v_poly + v_sphere + v_face + v_cyl
 
     @property
     def radius(self):

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -11,7 +11,8 @@ def test_volume(radius):
     v_cube = 1
     v_sphere = (4 / 3) * np.pi * radius ** 3
     v_cyl = 12 * (np.pi * radius ** 2) / 4
-    assert np.isclose(sphero_cube.volume, v_cube + v_sphere + v_cyl)
+    v_face = sphero_cube.polyhedron.surface_area * radius
+    assert np.isclose(sphero_cube.volume, v_cube + v_sphere + v_face + v_cyl)
 
 
 def test_volume_polyhedron(convex_cube, cube_points):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
This PR fixes a bug in the spheropolyhedron volume calculation and adds the ability to compute circumspheres and inspheres from center.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/euclid/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/euclid/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/euclid/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/euclid/blob/master/doc/source/credits.rst).
