### PR TITLE
Improve golden ratio documentation

### DIFF
--- a/coxeter/shape_families/plane_shape_families.py
+++ b/coxeter/shape_families/plane_shape_families.py
@@ -306,9 +306,9 @@ class Family523(TruncationPlaneShapeFamily):
 
     :math:`c \in [S^2, 3]`
 
-    where :math:`s = \frac{1}{2}\left(\sqrt{5} - 1\right)` and
-    :math:`S = \frac{1}{2}\left(\sqrt{5} + 1\right)`. The :math:`b` parameter
-    is always equal to 2 for this family.
+    where :math:`S = \frac{1}{2}\left(\sqrt{5} + 1\right)` is the golden ratio and
+    :math:`s = \frac{1}{2}\left(\sqrt{5} - 1\right)` is its inverse. The :math:`b`
+    parameter is always equal to 2 for this family.
 
     The extremal shapes in this shape family are an icosidodecahedron at
     (:math:`1`, :math:`S^2`), an icosahedron at (:math:`s\sqrt{5}`, :math:`S^2`), a
@@ -316,11 +316,11 @@ class Family523(TruncationPlaneShapeFamily):
     (:math:`s\sqrt{5}`, :math:`3`).
     """
 
-    """The constant s (the inverse of the golden ratio)."""
     s = 1 / golden_ratio
+    """The constant s (the inverse of the golden ratio)."""
 
-    """The constant S (the golden ratio)."""
     S = golden_ratio
+    """The constant S (the golden ratio)."""
 
     def __call__(self, a, c):
         r"""Generate a shape for the provided parameters.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

Fix some issues with the documentation of the 523 shape family to clarify the nature of the constants S (the golden ratio) and s (its inverse).

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves #87 

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/euclid/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/euclid/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/euclid/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/euclid/blob/master/doc/source/credits.rst).
