### PR TITLE
added perimeter and circumference setters and tests

### DIFF
--- a/Credits.rst
+++ b/Credits.rst
@@ -79,6 +79,11 @@ William Zygmunt
 
 * Helped clean up utils module.
 
+Tobias Dwyer
+
+* Added getter and setter tests to some of the shape classes.
+* Added examples for the shape classes.
+
 
 Source code
 -----------

--- a/coxeter/shape_classes/circle.py
+++ b/coxeter/shape_classes/circle.py
@@ -41,10 +41,7 @@ class Circle(Shape2D):
     """
 
     def __init__(self, radius, center=(0, 0, 0)):
-        if radius > 0:
-            self._radius = radius
-        else:
-            raise ValueError("Radius must be greater than zero.")
+        self.radius = radius
         self._center = np.asarray(center)
 
     @property

--- a/coxeter/shape_classes/circle.py
+++ b/coxeter/shape_classes/circle.py
@@ -74,7 +74,10 @@ class Circle(Shape2D):
 
     @area.setter
     def area(self, value):
-        self._radius = np.sqrt(value / np.pi)
+        if value > 0:
+            self._radius = np.sqrt(value / np.pi)
+        else:
+            print("Area must be greater than zero.")
 
     @property
     def eccentricity(self):
@@ -91,7 +94,10 @@ class Circle(Shape2D):
 
     @perimeter.setter
     def perimeter(self, value):
-        self._radius = value / (2 * np.pi)
+        if value > 0:
+            self._radius = value / (2 * np.pi)
+        else:
+            print("Perimeter must be greater than zero.")
 
     @property
     def circumference(self):
@@ -100,7 +106,7 @@ class Circle(Shape2D):
 
     @circumference.setter
     def circumference(self, value):
-        self._radius = value / (2 * np.pi)
+        self.perimeter = value
 
     @property
     def planar_moments_inertia(self):

--- a/coxeter/shape_classes/circle.py
+++ b/coxeter/shape_classes/circle.py
@@ -41,7 +41,10 @@ class Circle(Shape2D):
     """
 
     def __init__(self, radius, center=(0, 0, 0)):
-        self._radius = radius
+        if radius > 0:
+            self._radius = radius
+        else:
+            raise ValueError("Radius must be greater than zero.")
         self._center = np.asarray(center)
 
     @property

--- a/coxeter/shape_classes/circle.py
+++ b/coxeter/shape_classes/circle.py
@@ -89,10 +89,18 @@ class Circle(Shape2D):
         """float: Get the perimeter of the circle."""
         return 2 * np.pi * self.radius
 
+    @perimeter.setter
+    def perimeter(self, value):
+        self._radius = value / (2 * np.pi)
+
     @property
     def circumference(self):
         """float: Get the circumference, alias for :meth:`~.Circle.perimeter`."""
         return self.perimeter
+
+    @circumference.setter
+    def circumference(self, value):
+        self._radius = value / (2 * np.pi)
 
     @property
     def planar_moments_inertia(self):

--- a/coxeter/shape_classes/circle.py
+++ b/coxeter/shape_classes/circle.py
@@ -64,8 +64,11 @@ class Circle(Shape2D):
         return self._radius
 
     @radius.setter
-    def radius(self, radius):
-        self._radius = radius
+    def radius(self, r):
+        if r > 0:
+            self._radius = r
+        else:
+            raise ValueError("Radius must be greater than zero.")
 
     @property
     def area(self):
@@ -75,9 +78,9 @@ class Circle(Shape2D):
     @area.setter
     def area(self, value):
         if value > 0:
-            self._radius = np.sqrt(value / np.pi)
+            self.radius = np.sqrt(value / np.pi)
         else:
-            print("Area must be greater than zero.")
+            raise ValueError("Area must be greater than zero.")
 
     @property
     def eccentricity(self):
@@ -95,9 +98,9 @@ class Circle(Shape2D):
     @perimeter.setter
     def perimeter(self, value):
         if value > 0:
-            self._radius = value / (2 * np.pi)
+            self.radius = value / (2 * np.pi)
         else:
-            print("Perimeter must be greater than zero.")
+            raise ValueError("Perimeter must be greater than zero.")
 
     @property
     def circumference(self):

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -135,6 +135,13 @@ class ConvexSpheropolyhedron(Shape3D):
         """float: The rounding radius."""
         return self._radius
 
+    @radius.setter
+    def radius(self, radius):
+        if radius > 0:
+            self._radius = radius
+        else:
+            print("Radius must be greater than zero.")
+
     @property
     def surface_area(self):
         """float: Get the surface area."""

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -70,7 +70,10 @@ class ConvexSpheropolyhedron(Shape3D):
 
     def __init__(self, vertices, radius):
         self._polyhedron = ConvexPolyhedron(vertices)
-        self._radius = radius
+        if radius >= 0:
+            self._radius = radius
+        else:
+            raise ValueError("Radius must be greater than zero.")
 
     @property
     def gsd_shape_spec(self):
@@ -137,10 +140,10 @@ class ConvexSpheropolyhedron(Shape3D):
 
     @radius.setter
     def radius(self, radius):
-        if radius > 0:
+        if radius >= 0:
             self._radius = radius
         else:
-            print("Radius must be greater than zero.")
+            raise ValueError("Radius must be greater than zero.")
 
     @property
     def surface_area(self):

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -70,10 +70,7 @@ class ConvexSpheropolyhedron(Shape3D):
 
     def __init__(self, vertices, radius):
         self._polyhedron = ConvexPolyhedron(vertices)
-        if radius >= 0:
-            self._radius = radius
-        else:
-            raise ValueError("Radius must be greater than zero.")
+        self.radius = radius
 
     @property
     def gsd_shape_spec(self):
@@ -143,7 +140,7 @@ class ConvexSpheropolyhedron(Shape3D):
         if radius >= 0:
             self._radius = radius
         else:
-            raise ValueError("Radius must be greater than zero.")
+            raise ValueError("Rounding radius must be greater than or equal to zero.")
 
     @property
     def surface_area(self):

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -88,9 +88,20 @@ def test_center():
 
 
 @given(floats(0.1, 1000))
-def test_get_radius(r):
+def test_radius_getter_setter(r):
     """Test getting and setting the radius."""
     circle = Circle(r)
     assert circle.radius == r
     circle.radius = r + 1
     assert circle.radius == r + 1
+
+
+def test_invalid_radius():
+    with pytest.raises(ValueError):
+        Circle(-1)
+
+
+def test_invalid_radius_setter():
+    circle = Circle(1)
+    with pytest.raises(ValueError):
+        circle.radius = -1

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -24,6 +24,10 @@ def test_perimeter_setter(perimeter):
     assert circle.radius == perimeter / (2 * np.pi)
     circle.perimeter = perimeter + 1
     assert circle.radius == (perimeter + 1) / (2 * np.pi)
+    circle.circumference = perimeter
+    assert circle.radius == perimeter / (2 * np.pi)
+    circle.circumference = perimeter + 1
+    assert circle.radius == (perimeter + 1) / (2 * np.pi)
 
 
 @given(floats(0.1, 1000))

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -17,6 +17,16 @@ def test_perimeter(r):
 
 
 @given(floats(0.1, 1000))
+def test_perimeter_setter(perimeter):
+    """Test setting the perimeter."""
+    circle = Circle(1)
+    circle.perimeter = perimeter
+    assert circle.radius == perimeter / (2 * np.pi)
+    circle.perimeter = perimeter + 1
+    assert circle.radius == (perimeter + 1) / (2 * np.pi)
+
+
+@given(floats(0.1, 1000))
 def test_area(r):
     circle = Circle(1)
     circle.radius = r

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -22,12 +22,16 @@ def test_perimeter_setter(perimeter):
     circle = Circle(1)
     circle.perimeter = perimeter
     assert circle.radius == perimeter / (2 * np.pi)
+    assert circle.perimeter == approx(perimeter)
     circle.perimeter = perimeter + 1
     assert circle.radius == (perimeter + 1) / (2 * np.pi)
+    assert circle.perimeter == approx(perimeter + 1)
     circle.circumference = perimeter
     assert circle.radius == perimeter / (2 * np.pi)
+    assert circle.circumference == approx(perimeter)
     circle.circumference = perimeter + 1
     assert circle.radius == (perimeter + 1) / (2 * np.pi)
+    assert circle.circumference == approx(perimeter + 1)
 
 
 @given(floats(0.1, 1000))

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -36,6 +36,23 @@ def test_surface_area_polyhedron(convex_cube):
     assert sphero_cube.surface_area == convex_cube.surface_area
 
 
+@given(r=floats(0.1, 1))
+def test_radius_getter_setter(r):
+    sphero_cube = make_sphero_cube(radius=r)
+    assert sphero_cube.radius == r
+    sphero_cube.radius = r + 1
+    assert sphero_cube.radius == r + 1
+
+
+def test_center_getter_setter():
+    """Test center getter and setter."""
+    r = 1.0
+    sphero_cube = make_sphero_cube(radius=r)
+    assert all(sphero_cube.center == (0.5, 0.5, 0.5))
+    sphero_cube.center = (1, 1, 1)
+    assert all(sphero_cube.center == (1, 1, 1))
+
+
 def test_inside_boundaries():
     sphero_cube = make_sphero_cube(radius=1)
 

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from hypothesis import given
 from hypothesis.strategies import floats
 
@@ -36,12 +37,25 @@ def test_surface_area_polyhedron(convex_cube):
     assert sphero_cube.surface_area == convex_cube.surface_area
 
 
-@given(r=floats(0.1, 1))
+@given(r=floats(0, 1.0))
 def test_radius_getter_setter(r):
     sphero_cube = make_sphero_cube(radius=r)
     assert sphero_cube.radius == r
     sphero_cube.radius = r + 1
     assert sphero_cube.radius == r + 1
+
+
+@given(r=floats(-1000, -1))
+def test_invalid_radius(r):
+    with pytest.raises(ValueError):
+        make_sphero_cube(radius=r)
+
+
+@given(r=floats(-1000, -1))
+def test_invalid_radius_setter(r):
+    sphero_cube = make_sphero_cube(1)
+    with pytest.raises(ValueError):
+        sphero_cube.radius = r
 
 
 def test_center_getter_setter():


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
added perimeter and circumference getter and setter tests and the ability to set the circumference and perimeter of a circle

## Description
<!-- Describe your changes in detail -->
simple, see summary
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
consistency between what we can get and set
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
