### PR TITLE
Enable doctests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
             python -m flake8 --show-source coxeter/
             # Ignore isort errors in tests that are due to ambiguity over whether or not coxeter is third party.
             python -m flake8 --extend-ignore=I001,I004 --show-source tests/
-            python -m pytest --doctest-modules
+            python -m pytest
             python --version
             python -m pip --version
             python -m pip install --progress-bar off --user -U twine wheel setuptools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
             python -m pip install .[test] --progress-bar off --user
             python -c "import numpy; print('numpy', numpy.__version__)"
             python -c "import scipy; print('scipy', scipy.__version__)"
-            python -m pytest --doctest-modules
+            python -m pytest
 
   test-3.7:
     <<: *test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
             python -m pip install .[test] --progress-bar off --user
             python -c "import numpy; print('numpy', numpy.__version__)"
             python -c "import scipy; print('scipy', scipy.__version__)"
-            pytest
+            python -m pytest --doctest-modules
 
   test-3.7:
     <<: *test-template
@@ -66,7 +66,7 @@ jobs:
             python -m flake8 --show-source coxeter/
             # Ignore isort errors in tests that are due to ambiguity over whether or not coxeter is third party.
             python -m flake8 --extend-ignore=I001,I004 --show-source tests/
-            python -m pytest
+            python -m pytest --doctest-modules
             python --version
             python -m pip --version
             python -m pip install --progress-bar off --user -U twine wheel setuptools

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -16,6 +16,7 @@ Changed
 
 -  Shape family API is now entirely based on class methods rather than a call operator.
 -  The parent ShapeFamily class is now part of the public API.
+-  Doctests are now run as part of pytest.
 
 Fixed
 ~~~~~

--- a/Credits.rst
+++ b/Credits.rst
@@ -46,6 +46,7 @@ Bradley Dice
 * Added CircleCI support.
 * Add ability to check if points are contained in convex spheropolyhedra.
 * Revised and edited all documentation.
+* Updated doctests to be part of pytest suite.
 
 Brandon Butler
 

--- a/coxeter/__doctest_fixtures.py
+++ b/coxeter/__doctest_fixtures.py
@@ -11,7 +11,6 @@ is loaded as part of normal pytest runs and injects the appropriate variable int
 pytest doctest namespace.
 """
 
-import numpy as np
 import pytest
 
 import coxeter
@@ -22,4 +21,3 @@ import coxeter
 def setup_namespace(doctest_namespace):
     """Configure the global doctest_namespace fixture."""
     doctest_namespace["coxeter"] = coxeter
-    doctest_namespace["np"] = np

--- a/coxeter/__doctest_fixtures.py
+++ b/coxeter/__doctest_fixtures.py
@@ -11,6 +11,7 @@ is loaded as part of normal pytest runs and injects the appropriate variable int
 pytest doctest namespace.
 """
 
+import numpy as np
 import pytest
 
 import coxeter
@@ -18,6 +19,7 @@ import coxeter
 
 # Allow all doctests to access the parent coxeter namespace.
 @pytest.fixture(autouse=True)
-def add_coxeter(doctest_namespace):
-    """Add coxeter to the global doctest_namespace fixture."""
+def setup_namespace(doctest_namespace):
+    """Configure the global doctest_namespace fixture."""
     doctest_namespace["coxeter"] = coxeter
+    doctest_namespace["np"] = np

--- a/coxeter/shape_classes/circle.py
+++ b/coxeter/shape_classes/circle.py
@@ -37,6 +37,7 @@ class Circle(Shape2D):
         7.853981633974483
         >>> circle.radius
         1.0
+
     """
 
     def __init__(self, radius, center=(0, 0, 0)):

--- a/coxeter/shape_classes/circle.py
+++ b/coxeter/shape_classes/circle.py
@@ -17,6 +17,7 @@ class Circle(Shape2D):
 
     Example:
         >>> circle = coxeter.shape_classes.circle.Circle(radius=1.0, center=(1, 1, 1))
+        >>> import numpy as np
         >>> assert np.isclose(circle.area, np.pi)
         >>> circle.center
         array([1, 1, 1])

--- a/coxeter/shape_classes/circle.py
+++ b/coxeter/shape_classes/circle.py
@@ -14,9 +14,9 @@ class Circle(Shape2D):
         center (Sequence[float]):
             The coordinates of the center of the circle (Default
             value: (0, 0, 0)).
-    Example::
-        >>> circle = coxeter.shape_classes.circle
-        .Circle(radius=1.0,center=(1,1,1))
+
+    Example:
+        >>> circle = coxeter.shape_classes.circle.Circle(radius=1.0, center=(1, 1, 1))
         >>> circle.area
         3.141592653589793
         >>> circle.center
@@ -32,8 +32,7 @@ class Circle(Shape2D):
         >>> circle.perimeter
         6.283185307179586
         >>> circle.planar_moments_inertia
-        (3.9269908169872414, 3.9269908169872414
-        , 3.141592653589793)
+        (3.9269908169872414, 3.9269908169872414, 3.141592653589793)
         >>> circle.polar_moment_inertia
         7.853981633974483
         >>> circle.radius

--- a/coxeter/shape_classes/circle.py
+++ b/coxeter/shape_classes/circle.py
@@ -17,24 +17,21 @@ class Circle(Shape2D):
 
     Example:
         >>> circle = coxeter.shape_classes.circle.Circle(radius=1.0, center=(1, 1, 1))
-        >>> circle.area
-        3.141592653589793
+        >>> assert np.isclose(circle.area, np.pi)
         >>> circle.center
         array([1, 1, 1])
-        >>> circle.circumference
-        6.283185307179586
+        >>> assert np.isclose(circle.circumference, 2 * np.pi)
         >>> circle.eccentricity
         0
         >>> circle.gsd_shape_spec
         {'type': 'Sphere', 'diameter': 2.0}
         >>> circle.iq
         1
-        >>> circle.perimeter
-        6.283185307179586
-        >>> circle.planar_moments_inertia
-        (3.9269908169872414, 3.9269908169872414, 3.141592653589793)
-        >>> circle.polar_moment_inertia
-        7.853981633974483
+        >>> assert np.isclose(circle.perimeter, 2 * np.pi)
+        >>> assert np.allclose(
+        ...   circle.planar_moments_inertia,
+        ...   (5. / 4. * np.pi, 5. / 4. * np.pi, np.pi))
+        >>> assert np.isclose(circle.polar_moment_inertia, 5. / 2. * np.pi)
         >>> circle.radius
         1.0
 

--- a/coxeter/shape_classes/convex_polygon.py
+++ b/coxeter/shape_classes/convex_polygon.py
@@ -61,6 +61,7 @@ class ConvexPolygon(Polygon):
     Example:
         >>> square = coxeter.shape_classes.ConvexPolygon(
         ...   [[1, 1], [-1, -1], [1, -1], [-1, 1]])
+        >>> import numpy as np
         >>> assert np.isclose(square.area, 4.0)
         >>> assert np.isclose(
         ...   square.bounding_circle.radius,

--- a/coxeter/shape_classes/convex_polygon.py
+++ b/coxeter/shape_classes/convex_polygon.py
@@ -76,7 +76,8 @@ class ConvexPolygon(Polygon):
         >>> circle.area
         6.2831853071795845
         >>> square.gsd_shape_spec
-        {'type': 'Polygon', 'vertices': [[1.0, 1.0, 0.0], [-1.0, 1.0, 0.0], [-1.0, -1.0, 0.0], [1.0, -1.0, 0.0]]}
+        {'type': 'Polygon', 'vertices': [[1.0, 1.0, 0.0], [-1.0, 1.0, 0.0],
+        [-1.0, -1.0, 0.0], [1.0, -1.0, 0.0]]}
         >>> circle = square.incircle_from_center
         >>> circle.radius
         1.0

--- a/coxeter/shape_classes/convex_polygon.py
+++ b/coxeter/shape_classes/convex_polygon.py
@@ -61,40 +61,31 @@ class ConvexPolygon(Polygon):
     Example:
         >>> square = coxeter.shape_classes.ConvexPolygon(
         ...   [[1, 1], [-1, -1], [1, -1], [-1, 1]])
-        >>> square.area
-        4.0
-        >>> circle = square.bounding_circle
-        >>> circle.radius
-        1.4142135623730954
-        >>> circle.area
-        6.283185307179589
+        >>> assert np.isclose(square.area, 4.0)
+        >>> assert np.isclose(
+        ...   square.bounding_circle.radius,
+        ...   np.sqrt(2.))
         >>> square.center
         array([0., 0., 0.])
-        >>> circle = square.circumcircle
-        >>> circle.radius
-        1.414213562373095
-        >>> circle.area
-        6.2831853071795845
+        >>> assert np.isclose(
+        ...   square.circumcircle.radius,
+        ...   np.sqrt(2.))
         >>> square.gsd_shape_spec
         {'type': 'Polygon', 'vertices': [[1.0, 1.0, 0.0], [-1.0, 1.0, 0.0],
         [-1.0, -1.0, 0.0], [1.0, -1.0, 0.0]]}
-        >>> circle = square.incircle_from_center
-        >>> circle.radius
-        1.0
-        >>> circle.area
-        3.141592653589793
-        >>> square.inertia_tensor
-        array([[0.        , 0.        , 0.        ],
-               [0.        , 0.        , 0.        ],
-               [0.        , 0.        , 2.66666667]])
+        >>> assert np.isclose(square.incircle_from_center.radius, 1.0)
+        >>> assert np.allclose(
+        ...   square.inertia_tensor,
+        ...   [[0., 0., 0.],
+        ...    [0., 0., 0.],
+        ...    [0., 0., 8. / 3.]])
         >>> square.normal
         array([0., 0., 1.])
-        >>> square.planar_moments_inertia
-        (1.3333333333333333, 1.3333333333333333, 0.0)
-        >>> square.polar_moment_inertia
-        2.6666666666666665
-        >>> square.signed_area
-        4.0
+        >>> assert np.allclose(
+        ...   square.planar_moments_inertia,
+        ...   (4. / 3., 4. / 3., 0.))
+        >>> assert np.isclose(square.polar_moment_inertia, 8. / 3.)
+        >>> assert np.isclose(square.signed_area, 4.0)
         >>> square.vertices
         array([[ 1.,  1.,  0.],
                [-1.,  1.,  0.],

--- a/coxeter/shape_classes/convex_polygon.py
+++ b/coxeter/shape_classes/convex_polygon.py
@@ -100,6 +100,7 @@ class ConvexPolygon(Polygon):
                [-1.,  1.,  0.],
                [-1., -1.,  0.],
                [ 1., -1.,  0.]])
+
     """
 
     def __init__(self, vertices, normal=None, planar_tolerance=1e-5):

--- a/coxeter/shape_classes/convex_polygon.py
+++ b/coxeter/shape_classes/convex_polygon.py
@@ -76,8 +76,7 @@ class ConvexPolygon(Polygon):
         >>> circle.area
         6.2831853071795845
         >>> square.gsd_shape_spec
-        {'type': 'Polygon', 'vertices': [[1.0, 1.0, 0.0],
-        [-1.0, 1.0, 0.0], [-1.0, -1.0, 0.0], [1.0, -1.0, 0.0]]}
+        {'type': 'Polygon', 'vertices': [[1.0, 1.0, 0.0], [-1.0, 1.0, 0.0], [-1.0, -1.0, 0.0], [1.0, -1.0, 0.0]]}
         >>> circle = square.incircle_from_center
         >>> circle.radius
         1.0

--- a/coxeter/shape_classes/convex_polygon.py
+++ b/coxeter/shape_classes/convex_polygon.py
@@ -57,9 +57,10 @@ class ConvexPolygon(Polygon):
             Providing this argument may be necessary if you have a large
             number of vertices and are rotated significantly out of the
             plane.
-    Example::
-        >>> square = coxeter.shape_classes.ConvexPolygon([[1,1],[-1,-1],
-                                                          [1,-1],[-1,1]])
+
+    Example:
+        >>> square = coxeter.shape_classes.ConvexPolygon(
+        ...   [[1, 1], [-1, -1], [1, -1], [-1, 1]])
         >>> square.area
         4.0
         >>> circle = square.bounding_circle

--- a/coxeter/shape_classes/convex_polyhedron.py
+++ b/coxeter/shape_classes/convex_polyhedron.py
@@ -19,10 +19,11 @@ class ConvexPolyhedron(Polyhedron):
     Args:
         vertices (:math:`(N, 3)` :class:`numpy.ndarray`):
             The vertices of the polyhedron.
-    Example::
-        >>> cube = coxeter.shape_classes.ConvexPolyhedron([[1,1,1],
-        [1,-1,1],[1,1,-1],[1,-1,-1],[-1,1,1],[-1,-1,1],
-        [-1,1,-1],[-1,-1,-1]])
+
+    Example:
+        >>> cube = coxeter.shape_classes.ConvexPolyhedron(
+        ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
+        ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
         >>> cube.asphericity
         1.5
         >>> sphere = cube.bounding_sphere

--- a/coxeter/shape_classes/convex_polyhedron.py
+++ b/coxeter/shape_classes/convex_polyhedron.py
@@ -26,9 +26,9 @@ class ConvexPolyhedron(Polyhedron):
         ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
         >>> cube.asphericity
         1.5
-        >>> sphere = cube.bounding_sphere
-        >>> sphere.radius
-        1.7320508075688776
+        >>> bounding_sphere = cube.bounding_sphere
+        >>> bounding_sphere.radius
+        1.7320508...
         >>> cube.center
         array([0., 0., 0.])
         >>> sphere = cube.circumsphere
@@ -38,9 +38,13 @@ class ConvexPolyhedron(Polyhedron):
         >>> sphere.radius
         1.7320508075688772
         >>> cube.faces
-        [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4], dtype=int32), array([6, 7, 5, 4], dtype=int32), array([0, 1, 3, 2], dtype=int32), array([5, 7, 3, 1], dtype=int32), array([2, 3, 7, 6], dtype=int32)]
+        [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4], dtype=int32),
+        array([6, 7, 5, 4], dtype=int32), array([0, 1, 3, 2], dtype=int32),
+        array([5, 7, 3, 1], dtype=int32), array([2, 3, 7, 6], dtype=int32)]
         >>> cube.gsd_shape_spec
-        {'type': 'ConvexPolyhedron', 'vertices': [[1.0, 1.0, 1.0], [1.0, -1.0, 1.0], [1.0, 1.0, -1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, 1.0], [-1.0, -1.0, 1.0], [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]]}
+        {'type': 'ConvexPolyhedron', 'vertices': [[1.0, 1.0, 1.0], [1.0, -1.0, 1.0],
+        [1.0, 1.0, -1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, 1.0], [-1.0, -1.0, 1.0],
+        [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]]}
         >>> cube.inertia_tensor
         array([[5.33333333, 0.        , 0.        ],
                [0.        , 5.33333333, 0.        ],
@@ -53,7 +57,8 @@ class ConvexPolyhedron(Polyhedron):
         >>> cube.mean_curvature
         1.5
         >>> cube.neighbors
-        [array([1, 2, 3, 4]), array([0, 2, 3, 5]), array([0, 1, 4, 5]), array([0, 1, 4, 5]), array([0, 2, 3, 5]), array([1, 2, 3, 4])]
+        [array([1, 2, 3, 4]), array([0, 2, 3, 5]), array([0, 1, 4, 5]),
+        array([0, 1, 4, 5]), array([0, 2, 3, 5]), array([1, 2, 3, 4])]
         >>> cube.normals
         array([[-0., -0.,  1.],
                [-0.,  1., -0.],

--- a/coxeter/shape_classes/convex_polyhedron.py
+++ b/coxeter/shape_classes/convex_polyhedron.py
@@ -38,15 +38,9 @@ class ConvexPolyhedron(Polyhedron):
         >>> sphere.radius
         1.7320508075688772
         >>> cube.faces
-        [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4],
-        dtype=int32), array([6, 7, 5, 4], dtype=int32),
-        array([0, 1, 3, 2], dtype=int32), array([5, 7, 3, 1],
-        dtype=int32), array([2, 3, 7, 6], dtype=int32)]
+        [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4], dtype=int32), array([6, 7, 5, 4], dtype=int32), array([0, 1, 3, 2], dtype=int32), array([5, 7, 3, 1], dtype=int32), array([2, 3, 7, 6], dtype=int32)]
         >>> cube.gsd_shape_spec
-        {'type': 'ConvexPolyhedron', 'vertices': [[1.0, 1.0, 1.0],
-        [1.0, -1.0, 1.0], [1.0, 1.0, -1.0], [1.0, -1.0, -1.0],
-        [-1.0, 1.0, 1.0], [-1.0, -1.0, 1.0],
-        [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]]}
+        {'type': 'ConvexPolyhedron', 'vertices': [[1.0, 1.0, 1.0], [1.0, -1.0, 1.0], [1.0, 1.0, -1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, 1.0], [-1.0, -1.0, 1.0], [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]]}
         >>> cube.inertia_tensor
         array([[5.33333333, 0.        , 0.        ],
                [0.        , 5.33333333, 0.        ],
@@ -59,9 +53,7 @@ class ConvexPolyhedron(Polyhedron):
         >>> cube.mean_curvature
         1.5
         >>> cube.neighbors
-        [array([1, 2, 3, 4]), array([0, 2, 3, 5]),
-        array([0, 1, 4, 5]), array([0, 1, 4, 5]),
-        array([0, 2, 3, 5]), array([1, 2, 3, 4])]
+        [array([1, 2, 3, 4]), array([0, 2, 3, 5]), array([0, 1, 4, 5]), array([0, 1, 4, 5]), array([0, 2, 3, 5]), array([1, 2, 3, 4])]
         >>> cube.normals
         array([[-0., -0.,  1.],
                [-0.,  1., -0.],

--- a/coxeter/shape_classes/convex_polyhedron.py
+++ b/coxeter/shape_classes/convex_polyhedron.py
@@ -85,6 +85,7 @@ class ConvexPolyhedron(Polyhedron):
                [-1., -1., -1.]])
         >>> cube.volume
         8.0
+
     """
 
     def __init__(self, vertices):

--- a/coxeter/shape_classes/convex_polyhedron.py
+++ b/coxeter/shape_classes/convex_polyhedron.py
@@ -24,6 +24,7 @@ class ConvexPolyhedron(Polyhedron):
         >>> cube = coxeter.shape_classes.ConvexPolyhedron(
         ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
         ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
+        >>> import numpy as np
         >>> assert np.isclose(cube.asphericity, 1.5)
         >>> bounding_sphere = cube.bounding_sphere
         >>> assert np.isclose(bounding_sphere.radius, np.sqrt(3))

--- a/coxeter/shape_classes/convex_polyhedron.py
+++ b/coxeter/shape_classes/convex_polyhedron.py
@@ -24,19 +24,13 @@ class ConvexPolyhedron(Polyhedron):
         >>> cube = coxeter.shape_classes.ConvexPolyhedron(
         ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
         ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
-        >>> cube.asphericity
-        1.5
+        >>> assert np.isclose(cube.asphericity, 1.5)
         >>> bounding_sphere = cube.bounding_sphere
-        >>> bounding_sphere.radius
-        1.7320508...
+        >>> assert np.isclose(bounding_sphere.radius, np.sqrt(3))
         >>> cube.center
         array([0., 0., 0.])
-        >>> sphere = cube.circumsphere
-        >>> sphere.radius
-        1.7320508075688772
-        >>> sphere = cube.circumsphere_from_center
-        >>> sphere.radius
-        1.7320508075688772
+        >>> circumsphere = cube.circumsphere
+        >>> assert np.isclose(circumsphere.radius, np.sqrt(3))
         >>> cube.faces
         [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4], dtype=int32),
         array([6, 7, 5, 4], dtype=int32), array([0, 1, 3, 2], dtype=int32),
@@ -45,17 +39,14 @@ class ConvexPolyhedron(Polyhedron):
         {'type': 'ConvexPolyhedron', 'vertices': [[1.0, 1.0, 1.0], [1.0, -1.0, 1.0],
         [1.0, 1.0, -1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, 1.0], [-1.0, -1.0, 1.0],
         [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]]}
-        >>> cube.inertia_tensor
-        array([[5.33333333, 0.        , 0.        ],
-               [0.        , 5.33333333, 0.        ],
-               [0.        , 0.        , 5.33333333]])
+        >>> assert np.allclose(
+        ...   cube.inertia_tensor,
+        ...   np.diag([16. / 3., 16. / 3., 16. / 3.]))
         >>> sphere = cube.insphere_from_center
         >>> sphere.radius
         1.0
-        >>> cube.iq
-        0.5235987755982988
-        >>> cube.mean_curvature
-        1.5
+        >>> assert np.isclose(cube.iq, np.pi / 6.)
+        >>> assert np.isclose(cube.mean_curvature, 1.5)
         >>> cube.neighbors
         [array([1, 2, 3, 4]), array([0, 2, 3, 5]), array([0, 1, 4, 5]),
         array([0, 1, 4, 5]), array([0, 2, 3, 5]), array([1, 2, 3, 4])]
@@ -72,8 +63,7 @@ class ConvexPolyhedron(Polyhedron):
         8
         >>> cube.surface_area
         24.0
-        >>> cube.tau
-        1.1780972450961724
+        >>> assert np.isclose(cube.tau, 3. / 8. * np.pi)
         >>> cube.vertices
         array([[ 1.,  1.,  1.],
                [ 1., -1.,  1.],
@@ -83,8 +73,7 @@ class ConvexPolyhedron(Polyhedron):
                [-1., -1.,  1.],
                [-1.,  1., -1.],
                [-1., -1., -1.]])
-        >>> cube.volume
-        8.0
+        >>> assert np.isclose(cube.volume, 8.)
 
     """
 

--- a/coxeter/shape_classes/convex_spheropolygon.py
+++ b/coxeter/shape_classes/convex_spheropolygon.py
@@ -94,7 +94,7 @@ class ConvexSpheropolygon(Shape2D):
 
     @property
     def polygon(self):
-        """:class:`~coxeter.shape_classes.ConvexPolygon`: The underlying polygon."""  # noqa: E501
+        """:class:`~coxeter.shape_classes.ConvexPolygon`: The underlying polygon."""
         return self._polygon
 
     @property

--- a/coxeter/shape_classes/convex_spheropolygon.py
+++ b/coxeter/shape_classes/convex_spheropolygon.py
@@ -26,9 +26,10 @@ class ConvexSpheropolygon(Shape2D):
             arbitrary choice may not preserve the orientation of the
             provided vertices, users may provide a normal instead
             (Default value: None).
-    Example::
+
+    Example:
         >>> rounded_tri = coxeter.shape_classes.ConvexSpheropolygon(
-        [[-1,0],[0,1],[1,0]],radius=.1)
+        ...   [[-1, 0], [0, 1], [1, 0]], radius=.1)
         >>> rounded_tri.area
         1.5142586390105168
         >>> rounded_tri.center
@@ -37,8 +38,7 @@ class ConvexSpheropolygon(Shape2D):
         {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0],
         [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]], 'rounding_radius': 0.1}
         >>> rounded_tri.polygon
-        <coxeter.shape_classes.convex_polygon.ConvexPolygon
-        object at 0x11c187f50>
+        <coxeter.shape_classes.convex_polygon.ConvexPolygon object at 0x11c187f50>
         >>> rounded_tri.radius
         0.1
         >>> rounded_tri.signed_area
@@ -74,9 +74,10 @@ class ConvexSpheropolygon(Shape2D):
                 center, when this flag is True the point closer to the center
                 comes first, otherwise the point further away comes first
                 (Default value: True).
-        Example::
+
+        Example:
             >>> rounded_tri = coxeter.shape_classes.ConvexSpheropolygon(
-            [[-1,0],[0,1],[1,0]],radius=.1)
+            ...   [[-1, 0], [0, 1], [1, 0]], radius=0.1)
             >>> rounded_tri.vertices
             array([[-1.,  0.,  0.],
                    [ 0.,  1.,  0.],

--- a/coxeter/shape_classes/convex_spheropolygon.py
+++ b/coxeter/shape_classes/convex_spheropolygon.py
@@ -35,7 +35,8 @@ class ConvexSpheropolygon(Shape2D):
         >>> rounded_tri.center
         array([0.        , 0.33333333, 0.        ])
         >>> rounded_tri.gsd_shape_spec
-        {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]], 'rounding_radius': 0.1}
+        {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]], 'rounding_radius': 0.1}
         >>> rounded_tri.polygon
         <coxeter.shape_classes.convex_polygon.ConvexPolygon object at 0x...>
         >>> rounded_tri.radius

--- a/coxeter/shape_classes/convex_spheropolygon.py
+++ b/coxeter/shape_classes/convex_spheropolygon.py
@@ -35,10 +35,9 @@ class ConvexSpheropolygon(Shape2D):
         >>> rounded_tri.center
         array([0.        , 0.33333333, 0.        ])
         >>> rounded_tri.gsd_shape_spec
-        {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]], 'rounding_radius': 0.1}
+        {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]], 'rounding_radius': 0.1}
         >>> rounded_tri.polygon
-        <coxeter.shape_classes.convex_polygon.ConvexPolygon object at 0x11c187f50>
+        <coxeter.shape_classes.convex_polygon.ConvexPolygon object at 0x...>
         >>> rounded_tri.radius
         0.1
         >>> rounded_tri.signed_area

--- a/coxeter/shape_classes/convex_spheropolygon.py
+++ b/coxeter/shape_classes/convex_spheropolygon.py
@@ -47,6 +47,7 @@ class ConvexSpheropolygon(Shape2D):
         array([[-1.,  0.,  0.],
                [ 0.,  1.,  0.],
                [ 1.,  0.,  0.]])
+
     """
 
     def __init__(self, vertices, radius, normal=None):
@@ -87,6 +88,7 @@ class ConvexSpheropolygon(Shape2D):
             array([[-1.,  0.,  0.],
                    [ 1.,  0.,  0.],
                    [ 0.,  1.,  0.]])
+
         """
         self._polygon.reorder_verts(clockwise, ref_index, increasing_length)
 

--- a/coxeter/shape_classes/convex_spheropolygon.py
+++ b/coxeter/shape_classes/convex_spheropolygon.py
@@ -32,9 +32,9 @@ class ConvexSpheropolygon(Shape2D):
         >>> rounded_tri = coxeter.shape_classes.ConvexSpheropolygon(
         ...   [[-1, 0], [0, 1], [1, 0]], radius=.1)
         >>> rounded_tri.area
-        1.5142586390105168
+        1.5142...
         >>> rounded_tri.center
-        array([0.        , 0.33333333, 0.        ])
+        array([0.        , 0.333..., 0.        ])
         >>> rounded_tri.gsd_shape_spec
         {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0],
         [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]], 'rounding_radius': 0.1}
@@ -43,7 +43,7 @@ class ConvexSpheropolygon(Shape2D):
         >>> rounded_tri.radius
         0.1
         >>> rounded_tri.signed_area
-        1.5142586390105168
+        1.5142...
         >>> rounded_tri.vertices
         array([[-1.,  0.,  0.],
                [ 0.,  1.,  0.],

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -187,7 +187,7 @@ class ConvexSpheropolyhedron(Shape3D):
             >>> sphero.is_inside([[0, 0, 0], [10, 10, 10]])
             array([ True, False])
 
-        """  # noqa: E501
+        """
         # Determine which points are in the polyhedron and which are in the
         # bounded volume of faces extruded by the rounding radius
         points = np.atleast_2d(points)
@@ -309,6 +309,7 @@ class ConvexSpheropolyhedron(Shape3D):
             >>> sphere = sphero.insphere_from_center
             >>> sphere.radius
             1.5
+
         """
         insphere = self._polyhedron.insphere_from_center
         insphere.radius += self._radius

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -84,7 +84,7 @@ class ConvexSpheropolyhedron(Shape3D):
 
     @property
     def polyhedron(self):
-        """:class:`~.ConvexPolyhedron`: The underlying polyhedron."""  # noqa: E501
+        """:class:`~.ConvexPolyhedron`: The underlying polyhedron."""
         return self._polyhedron
 
     @property

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -35,7 +35,9 @@ class ConvexSpheropolyhedron(Shape3D):
         >>> sphere.radius
         2.232050807568877
         >>> sphero.gsd_shape_spec
-        {'type': 'ConvexPolyhedron', 'vertices': [[1.0, 1.0, 1.0], [1.0, -1.0, 1.0], [1.0, 1.0, -1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, 1.0], [-1.0, -1.0, 1.0], [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]], 'rounding_radius': 0.5}
+        {'type': 'ConvexPolyhedron', 'vertices': [[1.0, 1.0, 1.0], [1.0, -1.0, 1.0],
+        [1.0, 1.0, -1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, 1.0], [-1.0, -1.0, 1.0],
+        [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]], 'rounding_radius': 0.5}
         >>> sphere = sphero.insphere_from_center
         >>> sphere.radius
         1.5

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -307,6 +307,7 @@ class ConvexSpheropolyhedron(Shape3D):
             ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]],
             ...   radius=0.5)
             >>> sphere = sphero.insphere_from_center
+            >>> import numpy as np
             >>> assert np.isclose(sphere.radius, 1.5)
 
         """

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -23,10 +23,12 @@ class ConvexSpheropolyhedron(Shape3D):
             The vertices of the underlying polyhedron.
         radius (float):
             The rounding radius of the spheropolyhedron.
-    Example::
+
+    Example:
         >>> sphero = coxeter.shape_classes.ConvexSpheropolyhedron(
-        [[1,1,1],[1,-1,1],[1,1,-1],[1,-1,-1],[-1,1,1],[-1,-1,1],[-1,1,-1],
-        [-1,-1,-1]],radius=0.5)
+        ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
+        ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]],
+        ...   radius=0.5)
         >>> sphero.center
         array([0., 0., 0.])
         >>> sphere = sphero.circumsphere_from_center
@@ -177,12 +179,15 @@ class ConvexSpheropolyhedron(Shape3D):
             :math:`(N, )` :class:`numpy.ndarray`:
                 Boolean array indicating which points are contained in the
                 spheropolyhedron.
-        Example::
-            >>> sphero = coxeter.shape_classes.ConvexSpheropolyhedron([
-            [1,1,1],[1,-1,1],[1,1,-1],[1,-1,-1],[-1,1,1],[-1,-1,1],
-            [-1,1,-1],[-1,-1,-1]],radius=0.5)
-            >>> sphero.is_inside([[0,0,0],[10,10,10]])
+
+        Example:
+            >>> sphero = coxeter.shape_classes.ConvexSpheropolyhedron(
+            ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
+            ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]],
+            ...   radius=0.5)
+            >>> sphero.is_inside([[0, 0, 0], [10, 10, 10]])
             array([ True, False])
+
         """  # noqa: E501
         # Determine which points are in the polyhedron and which are in the
         # bounded volume of faces extruded by the rounding radius

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -35,10 +35,7 @@ class ConvexSpheropolyhedron(Shape3D):
         >>> sphere.radius
         2.232050807568877
         >>> sphero.gsd_shape_spec
-        {'type': 'ConvexPolyhedron', 'vertices': [[1.0, 1.0, 1.0],
-        [1.0, -1.0, 1.0], [1.0, 1.0, -1.0], [1.0, -1.0, -1.0],
-        [-1.0, 1.0, 1.0], [-1.0, -1.0, 1.0], [-1.0, 1.0, -1.0],
-        [-1.0, -1.0, -1.0]], 'rounding_radius': 0.5}
+        {'type': 'ConvexPolyhedron', 'vertices': [[1.0, 1.0, 1.0], [1.0, -1.0, 1.0], [1.0, 1.0, -1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, 1.0], [-1.0, -1.0, 1.0], [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]], 'rounding_radius': 0.5}
         >>> sphere = sphero.insphere_from_center
         >>> sphere.radius
         1.5
@@ -303,8 +300,10 @@ class ConvexSpheropolyhedron(Shape3D):
         calculations.
 
         Example:
-            >>> sphero = coxeter.shape_classes.ConvexSpheropolyhedron([[1,1,1],[1,-1,1],
-            [1,1,-1],[1,-1,-1],[-1,1,1],[-1,-1,1],[-1,1,-1],[-1,-1,-1]],radius=0.5)
+            >>> sphero = coxeter.shape_classes.ConvexSpheropolyhedron(
+            ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
+            ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]],
+            ...   radius=0.5)
             >>> sphere = sphero.insphere_from_center
             >>> sphere.radius
             1.5

--- a/coxeter/shape_classes/convex_spheropolyhedron.py
+++ b/coxeter/shape_classes/convex_spheropolyhedron.py
@@ -25,23 +25,23 @@ class ConvexSpheropolyhedron(Shape3D):
             The rounding radius of the spheropolyhedron.
 
     Example:
-        >>> sphero = coxeter.shape_classes.ConvexSpheropolyhedron(
+        >>> spherocube = coxeter.shape_classes.ConvexSpheropolyhedron(
         ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
         ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]],
         ...   radius=0.5)
-        >>> sphero.center
+        >>> spherocube.center
         array([0., 0., 0.])
-        >>> sphere = sphero.circumsphere_from_center
+        >>> sphere = spherocube.circumsphere_from_center
         >>> sphere.radius
-        2.232050807568877
-        >>> sphero.gsd_shape_spec
+        2.2320...
+        >>> spherocube.gsd_shape_spec
         {'type': 'ConvexPolyhedron', 'vertices': [[1.0, 1.0, 1.0], [1.0, -1.0, 1.0],
         [1.0, 1.0, -1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, 1.0], [-1.0, -1.0, 1.0],
         [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]], 'rounding_radius': 0.5}
-        >>> sphere = sphero.insphere_from_center
+        >>> sphere = spherocube.insphere_from_center
         >>> sphere.radius
         1.5
-        >>> cube = sphero.polyhedron
+        >>> cube = spherocube.polyhedron
         >>> cube.vertices
         array([[ 1.,  1.,  1.],
                [ 1., -1.,  1.],
@@ -51,11 +51,11 @@ class ConvexSpheropolyhedron(Shape3D):
                [-1., -1.,  1.],
                [-1.,  1., -1.],
                [-1., -1., -1.]])
-        >>> sphero.radius
+        >>> spherocube.radius
         0.5
-        >>> sphero.surface_area
-        45.99114857512855
-        >>> sphero.vertices
+        >>> spherocube.surface_area
+        45.991...
+        >>> spherocube.vertices
         array([[ 1.,  1.,  1.],
                [ 1., -1.,  1.],
                [ 1.,  1., -1.],
@@ -64,8 +64,8 @@ class ConvexSpheropolyhedron(Shape3D):
                [-1., -1.,  1.],
                [-1.,  1., -1.],
                [-1., -1., -1.]])
-        >>> sphero.volume
-        25.23598775598299
+        >>> spherocube.volume
+        25.235...
 
     """
 
@@ -307,8 +307,7 @@ class ConvexSpheropolyhedron(Shape3D):
             ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]],
             ...   radius=0.5)
             >>> sphere = sphero.insphere_from_center
-            >>> sphere.radius
-            1.5
+            >>> assert np.isclose(sphere.radius, 1.5)
 
         """
         insphere = self._polyhedron.insphere_from_center

--- a/coxeter/shape_classes/ellipse.py
+++ b/coxeter/shape_classes/ellipse.py
@@ -19,10 +19,9 @@ class Ellipse(Shape2D):
         center (Sequence[float]):
             The coordinates of the center of the ellipse (Default
             value: (0, 0, 0)).
-    Example::
-        >>> circle = coxeter.shape_classes.circle.Circle
-        (radius=1.0,center=(1,1,1))
-        >>> ellipse = coxeter.shape_classes.Ellipse(1.0,2.0)
+
+    Example:
+        >>> ellipse = coxeter.shape_classes.Ellipse(1.0, 2.0)
         >>> ellipse.a
         1.0
         >>> ellipse.b

--- a/coxeter/shape_classes/ellipse.py
+++ b/coxeter/shape_classes/ellipse.py
@@ -27,21 +27,21 @@ class Ellipse(Shape2D):
         >>> ellipse.b
         2.0
         >>> ellipse.area
-        6.283185307179586
+        6.28318...
         >>> ellipse.center
         array([0, 0, 0])
         >>> ellipse.circumference
-        9.688448220547675
+        9.68844...
         >>> ellipse.eccentricity
-        0.8660254037844386
+        0.86602...
         >>> ellipse.gsd_shape_spec
         {'type': 'Ellipsoid', 'a': 1.0, 'b': 2.0}
         >>> ellipse.iq
-        0.8411651810063192
+        0.84116...
         >>> ellipse.perimeter
-        9.688448220547675
+        9.68844...
         >>> ellipse.polar_moment_inertia
-        7.853981633974483
+        7.85398...
 
     """
 

--- a/coxeter/shape_classes/ellipsoid.py
+++ b/coxeter/shape_classes/ellipsoid.py
@@ -36,7 +36,7 @@ class Ellipsoid(Shape3D):
         array([0, 0, 0])
         >>> ellipsoid.gsd_shape_spec
         {'type': 'Ellipsoid', 'a': 1.0, 'b': 3.0, 'c': 2.0}
-        ellipsoid.inertia_tensor
+        >>> ellipsoid.inertia_tensor
         array([[65.34512719,  0.        ,  0.        ],
                [ 0.        , 25.13274123,  0.        ],
                [ 0.        ,  0.        , 50.26548246]])

--- a/coxeter/shape_classes/ellipsoid.py
+++ b/coxeter/shape_classes/ellipsoid.py
@@ -23,8 +23,9 @@ class Ellipsoid(Shape3D):
         center (Sequence[float]):
             The coordinates of the center of the ellipsoid (Default
             value: (0, 0, 0)).
-    Example::
-        >>> ellipsoid = coxeter.shape_classes.Ellipsoid(1.0,3.0,2.0)
+
+    Example:
+        >>> ellipsoid = coxeter.shape_classes.Ellipsoid(1.0, 3.0, 2.0)
         >>> ellipsoid.a
         1.0
         >>> ellipsoid.b
@@ -45,6 +46,7 @@ class Ellipsoid(Shape3D):
         48.88214630258205
         >>> ellipsoid.volume
         25.132741228718345
+
     """
 
     def __init__(self, a, b, c, center=(0, 0, 0)):
@@ -151,10 +153,12 @@ class Ellipsoid(Shape3D):
             :math:`(N, )` :class:`numpy.ndarray`:
                 Boolean array indicating which points are contained in the
                 ellipsoid.
-        Example::
-            >>> ellipsoid = coxeter.shape_classes.Ellipsoid(1.0,2.0,3.0)
-            >>> ellipsoid.is_inside([[0,0,0],[100,1,1]])
+
+        Example:
+            >>> ellipsoid = coxeter.shape_classes.Ellipsoid(1.0, 2.0, 3.0)
+            >>> ellipsoid.is_inside([[0, 0, 0], [100, 1, 1]])
             array([ True, False])
+
         """
         points = np.atleast_2d(points) - self.center
         scale = np.array([self.a, self.b, self.c])

--- a/coxeter/shape_classes/ellipsoid.py
+++ b/coxeter/shape_classes/ellipsoid.py
@@ -37,15 +37,15 @@ class Ellipsoid(Shape3D):
         >>> ellipsoid.gsd_shape_spec
         {'type': 'Ellipsoid', 'a': 1.0, 'b': 3.0, 'c': 2.0}
         >>> ellipsoid.inertia_tensor
-        array([[65.34512719,  0.        ,  0.        ],
-               [ 0.        , 25.13274123,  0.        ],
-               [ 0.        ,  0.        , 50.26548246]])
+        array([[65.34512...,  0.        ,  0.        ],
+               [ 0.        , 25.13274...,  0.        ],
+               [ 0.        ,  0.        , 50.26548...]])
         >>> ellipsoid.iq
-        0.6116194575753466
+        0.61161...
         >>> ellipsoid.surface_area
-        48.88214630258205
+        48.88214...
         >>> ellipsoid.volume
-        25.132741228718345
+        25.13274...
 
     """
 

--- a/coxeter/shape_classes/polygon.py
+++ b/coxeter/shape_classes/polygon.py
@@ -251,7 +251,7 @@ class Polygon(Shape2D):
 
     @property
     def normal(self):
-        """:math:`(3, )` :class:`numpy.ndarray` of float: Get the normal vector."""  # noqa: E501
+        """:math:`(3, )` :class:`numpy.ndarray` of float: Get the normal vector."""
         return self._normal
 
     @property
@@ -484,7 +484,7 @@ class Polygon(Shape2D):
 
     @property
     def bounding_circle(self):
-        """:class:`~.Circle`: Get the minimal bounding circle."""  # noqa: E501
+        """:class:`~.Circle`: Get the minimal bounding circle."""
         if not MINIBALL:
             raise ImportError(
                 "The miniball module must be installed. It can "

--- a/coxeter/shape_classes/polygon.py
+++ b/coxeter/shape_classes/polygon.py
@@ -94,6 +94,7 @@ class Polygon(Shape2D):
 
     Example:
         >>> triangle = coxeter.shape_classes.Polygon([[-1, 0], [0, 1], [1, 0]])
+        >>> import numpy as np
         >>> assert np.isclose(triangle.area, 1.0)
         >>> bounding_circle = triangle.bounding_circle
         >>> assert np.isclose(bounding_circle.radius, 1.0)

--- a/coxeter/shape_classes/polygon.py
+++ b/coxeter/shape_classes/polygon.py
@@ -94,35 +94,25 @@ class Polygon(Shape2D):
 
     Example:
         >>> triangle = coxeter.shape_classes.Polygon([[-1, 0], [0, 1], [1, 0]])
-        >>> triangle.area
-        1.0
-        >>> circle = triangle.bounding_circle
-        >>> circle.radius
-        1.0
-        >>> triangle.center
-        array([0.        , 0.33333333, 0.        ])
-        >>> circle = triangle.circumcircle
-        >>> circle.radius
-        1.0
+        >>> assert np.isclose(triangle.area, 1.0)
+        >>> bounding_circle = triangle.bounding_circle
+        >>> assert np.isclose(bounding_circle.radius, 1.0)
+        >>> assert np.allclose(triangle.center, [0., 1. / 3., 0.])
+        >>> circumcircle = triangle.circumcircle
+        >>> assert np.isclose(circumcircle.radius, 1.0)
         >>> triangle.gsd_shape_spec
         {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0],
         [1.0, 0.0, 0.0]]}
-        >>> triangle.inertia_tensor
-        array([[0.11111111, 0.        , 0.        ],
-               [0.        , 0.        , 0.        ],
-               [0.        , 0.        , 0.33333333]])
+        >>> assert np.allclose(
+        ...   triangle.inertia_tensor,
+        ...   np.diag([1. / 9., 0., 1. / 3.]))
         >>> triangle.normal
         array([ 0., -0., -1.])
-        >>> triangle.planar_moments_inertia
-        (0.16666666666666666, 0.16666666666666666, 0.0)
-        >>> triangle.polar_moment_inertia
-        0.3333333333333333
-        >>> triangle.signed_area
-        1.0
-        >>> triangle.vertices
-        array([[-1.00000000e+00, -5.55111512e-17,  0.00000000e+00],
-               [ 0.00000000e+00,  1.00000000e+00,  0.00000000e+00],
-               [ 1.00000000e+00, -5.55111512e-17,  0.00000000e+00]])
+        >>> assert np.allclose(
+        ...   triangle.planar_moments_inertia,
+        ...   (1. / 6., 1. / 6., 0.))
+        >>> assert np.isclose(triangle.polar_moment_inertia, 1. / 3.)
+        >>> assert np.isclose(triangle.signed_area, 1.0)
 
     """
 

--- a/coxeter/shape_classes/polygon.py
+++ b/coxeter/shape_classes/polygon.py
@@ -105,7 +105,8 @@ class Polygon(Shape2D):
         >>> circle.radius
         1.0
         >>> triangle.gsd_shape_spec
-        {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]]}
+        {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0]]}
         >>> triangle.inertia_tensor
         array([[0.11111111, 0.        , 0.        ],
                [0.        , 0.        , 0.        ],

--- a/coxeter/shape_classes/polygon.py
+++ b/coxeter/shape_classes/polygon.py
@@ -211,9 +211,10 @@ class Polygon(Shape2D):
                 center, when this flag is True the point closer to the center
                 comes first, otherwise the point further away comes first
                 (Default value: True).
-        Example::
+
+        Example:
             >>> square = coxeter.shape_classes.ConvexPolygon(
-            [[-1,-1],[1,-1],[-1,1],[1,1]])
+            ...   [[-1, -1], [1, -1], [-1, 1], [1, 1]])
             >>> print(square.vertices)
             [[-1. -1.  0.]
              [ 1. -1.  0.]
@@ -225,6 +226,7 @@ class Polygon(Shape2D):
              [-1.  1.  0.]
              [ 1.  1.  0.]
              [ 1. -1.  0.]]
+
         """
         verts = _align_points_by_normal(self._normal, self._vertices - self.center)
 

--- a/coxeter/shape_classes/polygon.py
+++ b/coxeter/shape_classes/polygon.py
@@ -91,8 +91,9 @@ class Polygon(Shape2D):
             omitted, the class may produce invalid results if the user
             inputs incorrect coordinates, so this flag should be set to
             ``False`` with care.
-    Example::
-        >>> triangle = coxeter.shape_classes.Polygon([[-1,0],[0,1],[1,0]])
+
+    Example:
+        >>> triangle = coxeter.shape_classes.Polygon([[-1, 0], [0, 1], [1, 0]])
         >>> triangle.area
         1.0
         >>> circle = triangle.bounding_circle

--- a/coxeter/shape_classes/polygon.py
+++ b/coxeter/shape_classes/polygon.py
@@ -105,8 +105,7 @@ class Polygon(Shape2D):
         >>> circle.radius
         1.0
         >>> triangle.gsd_shape_spec
-        {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]]}
+        {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]]}
         >>> triangle.inertia_tensor
         array([[0.11111111, 0.        , 0.        ],
                [0.        , 0.        , 0.        ],

--- a/coxeter/shape_classes/polyhedron.py
+++ b/coxeter/shape_classes/polyhedron.py
@@ -340,7 +340,7 @@ class Polyhedron(Shape3D):
 
     @property
     def vertices(self):
-        """:math:`(N, 3)` :class:`numpy.ndarray`: Get the vertices of the polyhedron."""  # noqa: E501
+        """:math:`(N, 3)` :class:`numpy.ndarray`: Get the vertices of the polyhedron."""
         return self._vertices
 
     @property

--- a/coxeter/shape_classes/polyhedron.py
+++ b/coxeter/shape_classes/polyhedron.py
@@ -68,6 +68,7 @@ class Polyhedron(Shape3D):
         >>> cube = coxeter.shape_classes.Polyhedron(
         ...   vertices=cube.vertices, faces=cube.faces)
         >>> bounding_sphere = cube.bounding_sphere
+        >>> import numpy as np
         >>> assert np.isclose(bounding_sphere.radius, np.sqrt(3))
         >>> cube.center
         array([0., 0., 0.])
@@ -373,6 +374,7 @@ class Polyhedron(Shape3D):
             ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
             >>> cube = coxeter.shape_classes.Polyhedron(
             ...   vertices=cube.vertices,faces=cube.faces)
+            >>> import numpy as np
             >>> assert np.allclose(
             ...   cube.get_face_area([1, 2, 3]),
             ...   [4., 4., 4.])
@@ -544,6 +546,7 @@ class Polyhedron(Shape3D):
             ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
             >>> cube = coxeter.shape_classes.Polyhedron(
             ...   vertices=cube.vertices, faces=cube.faces)
+            >>> import numpy as np
             >>> assert np.isclose(cube.get_dihedral(1, 2), np.pi / 2.)
 
         """

--- a/coxeter/shape_classes/polyhedron.py
+++ b/coxeter/shape_classes/polyhedron.py
@@ -68,8 +68,7 @@ class Polyhedron(Shape3D):
         >>> cube = coxeter.shape_classes.Polyhedron(
         ...   vertices=cube.vertices, faces=cube.faces)
         >>> bounding_sphere = cube.bounding_sphere
-        >>> bounding_sphere.radius
-        1.7320508...
+        >>> assert np.isclose(bounding_sphere.radius, np.sqrt(3))
         >>> cube.center
         array([0., 0., 0.])
         >>> cube.circumsphere
@@ -85,12 +84,10 @@ class Polyhedron(Shape3D):
         [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4], dtype=int32),
         array([6, 7, 5, 4], dtype=int32), array([0, 1, 3, 2], dtype=int32),
         array([5, 7, 3, 1], dtype=int32), array([2, 3, 7, 6], dtype=int32)]}
-        >>> cube.inertia_tensor
-        array([[5.33333333, 0.        , 0.        ],
-               [0.        , 5.33333333, 0.        ],
-               [0.        , 0.        , 5.33333333]])
-        >>> cube.iq
-        0.5235987755982988
+        >>> assert np.allclose(
+        ...   cube.inertia_tensor,
+        ...   np.diag([16. / 3., 16. / 3., 16. / 3.]))
+        >>> assert np.isclose(cube.iq, np.pi / 6.)
         >>> cube.neighbors
         [array([1, 2, 3, 4]), array([0, 2, 3, 5]), array([0, 1, 4, 5]),
         array([0, 1, 4, 5]), array([0, 2, 3, 5]), array([1, 2, 3, 4])]
@@ -105,8 +102,7 @@ class Polyhedron(Shape3D):
         6
         >>> cube.num_vertices
         8
-        >>> cube.surface_area
-        24.0
+        >>> assert np.isclose(cube.surface_area, 24.0)
         >>> cube.vertices
         array([[ 1.,  1.,  1.],
                [ 1., -1.,  1.],
@@ -116,8 +112,7 @@ class Polyhedron(Shape3D):
                [-1., -1.,  1.],
                [-1.,  1., -1.],
                [-1., -1., -1.]])
-        >>> cube.volume
-        8.0
+        >>> assert np.isclose(cube.volume, 8.0)
 
     """
 
@@ -378,8 +373,9 @@ class Polyhedron(Shape3D):
             ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
             >>> cube = coxeter.shape_classes.Polyhedron(
             ...   vertices=cube.vertices,faces=cube.faces)
-            >>> cube.get_face_area([1, 2, 3])
-            array([4., 4., 4.])
+            >>> assert np.allclose(
+            ...   cube.get_face_area([1, 2, 3]),
+            ...   [4., 4., 4.])
 
         """
         if faces is None:
@@ -548,8 +544,7 @@ class Polyhedron(Shape3D):
             ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
             >>> cube = coxeter.shape_classes.Polyhedron(
             ...   vertices=cube.vertices, faces=cube.faces)
-            >>> cube.get_dihedral(1, 2)
-            1.5707963267948966
+            >>> assert np.isclose(cube.get_dihedral(1, 2), np.pi / 2.)
 
         """
         if b not in self.neighbors[a]:

--- a/coxeter/shape_classes/polyhedron.py
+++ b/coxeter/shape_classes/polyhedron.py
@@ -72,19 +72,11 @@ class Polyhedron(Shape3D):
         >>> cube.center
         array([0., 0., 0.])
         >>> cube.circumsphere
-        <coxeter.shape_classes.sphere.Sphere object at 0x1058fe610>
+        <coxeter.shape_classes.sphere.Sphere object at 0x...>
         >>> cube.faces
-        [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4], dtype=int32),
-        array([6, 7, 5, 4], dtype=int32), array([0, 1, 3, 2], dtype=int32),
-        array([5, 7, 3, 1], dtype=int32), array([2, 3, 7, 6], dtype=int32)]
+        [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4], dtype=int32), array([6, 7, 5, 4], dtype=int32), array([0, 1, 3, 2], dtype=int32), array([5, 7, 3, 1], dtype=int32), array([2, 3, 7, 6], dtype=int32)]
         >>> cube.gsd_shape_spec
-        {'type': 'Mesh', 'vertices': [[1.0, 1.0, 1.0], [1.0, -1.0, 1.0],
-        [1.0, 1.0, -1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, 1.0],
-        [-1.0, -1.0, 1.0], [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]],
-        'faces': [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4],
-        dtype=int32), array([6, 7, 5, 4], dtype=int32), array([0, 1, 3, 2],
-        dtype=int32), array([5, 7, 3, 1], dtype=int32), array([2, 3, 7, 6],
-        dtype=int32)]}
+        {'type': 'Mesh', 'vertices': [[1.0, 1.0, 1.0], [1.0, -1.0, 1.0], [1.0, 1.0, -1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, 1.0], [-1.0, -1.0, 1.0], [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]], 'faces': [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4], dtype=int32), array([6, 7, 5, 4], dtype=int32), array([0, 1, 3, 2], dtype=int32), array([5, 7, 3, 1], dtype=int32), array([2, 3, 7, 6], dtype=int32)]}
         >>> cube.inertia_tensor
         array([[5.33333333, 0.        , 0.        ],
                [0.        , 5.33333333, 0.        ],
@@ -92,8 +84,7 @@ class Polyhedron(Shape3D):
         >>> cube.iq
         0.5235987755982988
         >>> cube.neighbors
-        [array([1, 2, 3, 4]), array([0, 2, 3, 5]), array([0, 1, 4, 5]),
-        array([0, 1, 4, 5]), array([0, 2, 3, 5]), array([1, 2, 3, 4])]
+        [array([1, 2, 3, 4]), array([0, 2, 3, 5]), array([0, 1, 4, 5]), array([0, 1, 4, 5]), array([0, 2, 3, 5]), array([1, 2, 3, 4])]
         >>> cube.normals
         array([[ 0.,  0.,  1.],
                [ 0.,  1., -0.],

--- a/coxeter/shape_classes/polyhedron.py
+++ b/coxeter/shape_classes/polyhedron.py
@@ -65,18 +65,26 @@ class Polyhedron(Shape3D):
         >>> cube = coxeter.shape_classes.ConvexPolyhedron(
         ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
         ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
-        >>> cube = coxeter.shape_classes.Polyhedron(vertices=cube.vertices,faces=cube.faces)
+        >>> cube = coxeter.shape_classes.Polyhedron(
+        ...   vertices=cube.vertices, faces=cube.faces)
         >>> bounding_sphere = cube.bounding_sphere
         >>> bounding_sphere.radius
-        1.7320508075688776
+        1.7320508...
         >>> cube.center
         array([0., 0., 0.])
         >>> cube.circumsphere
         <coxeter.shape_classes.sphere.Sphere object at 0x...>
         >>> cube.faces
-        [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4], dtype=int32), array([6, 7, 5, 4], dtype=int32), array([0, 1, 3, 2], dtype=int32), array([5, 7, 3, 1], dtype=int32), array([2, 3, 7, 6], dtype=int32)]
+        [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4], dtype=int32),
+        array([6, 7, 5, 4], dtype=int32), array([0, 1, 3, 2], dtype=int32),
+        array([5, 7, 3, 1], dtype=int32), array([2, 3, 7, 6], dtype=int32)]
         >>> cube.gsd_shape_spec
-        {'type': 'Mesh', 'vertices': [[1.0, 1.0, 1.0], [1.0, -1.0, 1.0], [1.0, 1.0, -1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, 1.0], [-1.0, -1.0, 1.0], [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]], 'faces': [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4], dtype=int32), array([6, 7, 5, 4], dtype=int32), array([0, 1, 3, 2], dtype=int32), array([5, 7, 3, 1], dtype=int32), array([2, 3, 7, 6], dtype=int32)]}
+        {'type': 'Mesh', 'vertices': [[1.0, 1.0, 1.0], [1.0, -1.0, 1.0],
+        [1.0, 1.0, -1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, 1.0],
+        [-1.0, -1.0, 1.0], [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]], 'faces':
+        [array([4, 5, 1, 0], dtype=int32), array([0, 2, 6, 4], dtype=int32),
+        array([6, 7, 5, 4], dtype=int32), array([0, 1, 3, 2], dtype=int32),
+        array([5, 7, 3, 1], dtype=int32), array([2, 3, 7, 6], dtype=int32)]}
         >>> cube.inertia_tensor
         array([[5.33333333, 0.        , 0.        ],
                [0.        , 5.33333333, 0.        ],
@@ -84,7 +92,8 @@ class Polyhedron(Shape3D):
         >>> cube.iq
         0.5235987755982988
         >>> cube.neighbors
-        [array([1, 2, 3, 4]), array([0, 2, 3, 5]), array([0, 1, 4, 5]), array([0, 1, 4, 5]), array([0, 2, 3, 5]), array([1, 2, 3, 4])]
+        [array([1, 2, 3, 4]), array([0, 2, 3, 5]), array([0, 1, 4, 5]),
+        array([0, 1, 4, 5]), array([0, 2, 3, 5]), array([1, 2, 3, 4])]
         >>> cube.normals
         array([[ 0.,  0.,  1.],
                [ 0.,  1., -0.],

--- a/coxeter/shape_classes/polyhedron.py
+++ b/coxeter/shape_classes/polyhedron.py
@@ -60,14 +60,14 @@ class Polyhedron(Shape3D):
             Whether or not the faces of the polyhedron are all convex.
             This is used to determine whether certain operations like
             coplanar face merging are allowed (Default value: False).
-    Example::
-        >>> cube  = coxeter.shape_classes.ConvexPolyhedron([[1,1,1],
-        [1,-1,1],[1,1,-1],[1,-1,-1],[-1,1,1],
-        [-1,-1,1],[-1,1,-1],[-1,-1,-1]])
-        >>> cube = coxeter.shape_classes
-        .Polyhedron(vertices=cube.vertices,faces=cube.faces)
-        >>> sphere = cube.bounding_sphere
-        >>> sphere.radius
+
+    Example:
+        >>> cube = coxeter.shape_classes.ConvexPolyhedron(
+        ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
+        ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
+        >>> cube = coxeter.shape_classes.Polyhedron(vertices=cube.vertices,faces=cube.faces)
+        >>> bounding_sphere = cube.bounding_sphere
+        >>> bounding_sphere.radius
         1.7320508075688776
         >>> cube.center
         array([0., 0., 0.])
@@ -371,13 +371,14 @@ class Polyhedron(Shape3D):
 
         Returns:
             :class:`numpy.ndarray`: The area of each face.
-        Example::
-            >>> cube  = coxeter.shape_classes.ConvexPolyhedron([[1,1,1],
-            [1,-1,1],[1,1,-1],[1,-1,-1],[-1,1,1],[-1,-1,1],
-            [-1,1,-1],[-1,-1,-1]])
-            >>> cube  = coxeter.shape_classes.Polyhedron(
-            vertices=cube.vertices,faces=cube.faces)
-            >>> cube.get_face_area([1,2,3])
+
+        Example:
+            >>> cube = coxeter.shape_classes.ConvexPolyhedron(
+            ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
+            ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
+            >>> cube = coxeter.shape_classes.Polyhedron(
+            ...   vertices=cube.vertices,faces=cube.faces)
+            >>> cube.get_face_area([1, 2, 3])
             array([4., 4., 4.])
 
         """
@@ -546,14 +547,16 @@ class Polyhedron(Shape3D):
 
         Returns:
             float: The dihedral angle in radians.
-        Example::
-            >>> cube  = coxeter.shape_classes.ConvexPolyhedron([[1,1,1],
-            [1,-1,1],[1,1,-1],[1,-1,-1],[-1,1,1],[-1,-1,1],
-            [-1,1,-1],[-1,-1,-1]])
-            >>> cube  = coxeter.shape_classes.Polyhedron(
-            vertices=cube.vertices,faces=cube.faces)
-            >>> cube.get_dihedral(1,2)
+
+        Example:
+            >>> cube = coxeter.shape_classes.ConvexPolyhedron(
+            ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
+            ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
+            >>> cube = coxeter.shape_classes.Polyhedron(
+            ...   vertices=cube.vertices, faces=cube.faces)
+            >>> cube.get_dihedral(1, 2)
             1.5707963267948966
+
         """
         if b not in self.neighbors[a]:
             raise ValueError("The two faces are not neighbors.")
@@ -598,11 +601,12 @@ class Polyhedron(Shape3D):
         tensor. This method computes the inertia tensor of the shape, diagonalizes it,
         and then rotates the shape by the corresponding orthogonal transformation.
 
-        Example::
-            >>> cube  = coxeter.shape_classes.ConvexPolyhedron([[1,1,1],
-            [1,-1,1],[1,1,-1],[1,-1,-1],[-1,1,1],[-1,-1,1],[-1,1,-1],[-1,-1,-1]])
-            >>> cube  = coxeter.shape_classes.Polyhedron(vertices=cube.vertices
-            ,faces=cube.faces)
+        Example:
+            >>> cube = coxeter.shape_classes.ConvexPolyhedron(
+            ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
+            ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
+            >>> cube = coxeter.shape_classes.Polyhedron(
+            ...   vertices=cube.vertices, faces=cube.faces)
             >>> cube.diagonalize_inertia()
             >>> cube.vertices
             array([[ 1.,  1.,  1.],
@@ -613,6 +617,7 @@ class Polyhedron(Shape3D):
                    [-1., -1.,  1.],
                    [-1.,  1., -1.],
                    [-1., -1., -1.]])
+
         """
         principal_moments, principal_axes = np.linalg.eigh(self.inertia_tensor)
         self._vertices = np.dot(self._vertices, principal_axes)

--- a/coxeter/shape_classes/sphere.py
+++ b/coxeter/shape_classes/sphere.py
@@ -15,7 +15,8 @@ class Sphere(Shape3D):
         center (Sequence[float]):
             The coordinates of the center of the sphere (Default
             value: (0, 0, 0)).
-    Example::
+
+    Example:
         >>> sphere = coxeter.shape_classes.Sphere(1.0)
         >>> sphere.radius
         1.0
@@ -112,7 +113,8 @@ class Sphere(Shape3D):
             :math:`(N, )` :class:`numpy.ndarray`:
                 Boolean array indicating which points are contained in the
                 sphere.
-        Example::
+
+        Example:
             >>> sphere = coxeter.shape_classes.Sphere(1.0)
             >>> sphere.is_inside([[0,0,0],[20,20,20]])
             array([ True, False])

--- a/coxeter/shape_classes/sphere.py
+++ b/coxeter/shape_classes/sphere.py
@@ -18,25 +18,19 @@ class Sphere(Shape3D):
 
     Example:
         >>> sphere = coxeter.shape_classes.Sphere(1.0)
-        >>> sphere.radius
-        1.0
-        >>> sphere = coxeter.shape_classes.Sphere(1.0)
-        >>> sphere.center
-        array([0, 0, 0])
+        >>> assert np.isclose(sphere.radius, 1.0)
+        >>> assert np.allclose(sphere.center, [0., 0., 0.])
         >>> sphere.gsd_shape_spec
         {'type': 'Sphere', 'diameter': 2.0}
-        >>> sphere.inertia_tensor
-        array([[1.67551608, 0.        , 0.        ],
-               [0.        , 1.67551608, 0.        ],
-               [0.        , 0.        , 1.67551608]])
+        >>> assert np.allclose(
+        ...   np.diag(sphere.inertia_tensor),
+        ...   8. / 15. * np.pi)
         >>> sphere.iq
         1
-        >>> sphere.radius
-        1.0
         >>> sphere.surface_area
-        12.566370614359172
+        12.56637...
         >>> sphere.volume
-        4.1887902047863905
+        4.18879...
 
     """
 
@@ -116,7 +110,7 @@ class Sphere(Shape3D):
 
         Example:
             >>> sphere = coxeter.shape_classes.Sphere(1.0)
-            >>> sphere.is_inside([[0,0,0],[20,20,20]])
+            >>> sphere.is_inside([[0, 0, 0], [20, 20, 20]])
             array([ True, False])
 
         """

--- a/coxeter/shape_classes/sphere.py
+++ b/coxeter/shape_classes/sphere.py
@@ -118,6 +118,7 @@ class Sphere(Shape3D):
             >>> sphere = coxeter.shape_classes.Sphere(1.0)
             >>> sphere.is_inside([[0,0,0],[20,20,20]])
             array([ True, False])
+
         """
         points = np.atleast_2d(points) - self.center
         return np.linalg.norm(points, axis=-1) <= self.radius

--- a/coxeter/shape_families/__init__.py
+++ b/coxeter/shape_families/__init__.py
@@ -37,9 +37,10 @@ DOI_SHAPE_REPOSITORIES = _KeyedDefaultDict(_doi_shape_collection_factory)
 
 Each known DOI is associated with a list of shape families that can be used to generate
 the shapes from those papers. Currently supported DOIs are:
-    * 10.1126/science.1220869: :cite:`Damasceno2012`
-    * 10.1103/PhysRevX.4.011024: :cite:`Chen2014`
-    * 10.1021/nn204012y: :cite:`Damasceno2012`
+
+* 10.1126/science.1220869: :cite:`Damasceno2012`
+* 10.1103/PhysRevX.4.011024: :cite:`Chen2014`
+* 10.1021/nn204012y: :cite:`Damasceno2012`
 """
 
 

--- a/coxeter/shape_families/common_families.py
+++ b/coxeter/shape_families/common_families.py
@@ -34,7 +34,7 @@ class RegularNGonFamily(ShapeFamily):
 
         Returns:
              :class:`~.ConvexPolygon`: The corresponding regular polygon.
-        """  # noqa: E501
+        """
         return ConvexPolygon(cls.make_vertices(n))
 
     @classmethod
@@ -47,7 +47,7 @@ class RegularNGonFamily(ShapeFamily):
 
         Returns:
             :math:`(n, 3)` :class:`numpy.ndarray` of float: The vertices of the polygon.
-        """  # noqa: E501
+        """
         if n < 3:
             raise ValueError("Cannot generate an n-gon with fewer than 3 vertices.")
         r = 1  # The radius of the circle

--- a/coxeter/shape_families/plane_shape_families.py
+++ b/coxeter/shape_families/plane_shape_families.py
@@ -49,10 +49,11 @@ class TruncationPlaneShapeFamily(ShapeFamily):
     def get_plane_types(cls):
         """Get the types of the planes.
 
-        The types are encoded via an integer mapping:
-            type 0 corresponds to the parameter a.
-            type 1 corresponds to the parameter b.
-            type 2 corresponds to the parameter c.
+        The types are encoded via the following integer mapping:
+
+        * type 0 corresponds to the parameter a.
+        * type 1 corresponds to the parameter b.
+        * type 2 corresponds to the parameter c.
 
         Returns:
             (:math:`N_{planes}`, ) :class:`numpy.ndarray` of int:

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,4 +39,5 @@ known_third_party = hypothesis,pytest
 known_first_party = conftest,coxeter,utils
 
 [tool:pytest]
-addopts = -p coxeter.__doctest_fixtures
+addopts = --doctest-modules -p coxeter.__doctest_fixtures
+doctest_optionflags= NORMALIZE_WHITESPACE

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,4 @@ known_first_party = conftest,coxeter,utils
 
 [tool:pytest]
 addopts = --doctest-modules -p coxeter.__doctest_fixtures
-doctest_optionflags= NORMALIZE_WHITESPACE
+doctest_optionflags= NORMALIZE_WHITESPACE ELLIPSIS


### PR DESCRIPTION
## Description
This PR enables doctests in pytest, so they will run during continuous integration.

To make doctests work, I enabled two options.

`ELLIPSIS` allows non-deterministic results to be ignored by putting `...`.
`NORMALIZE_WHITESPACE` allows lines to be wrapped for flake8 even if the output does not contain newlines.

I also reformatted the examples sections so they render better. Resolves #104.

## Motivation and Context
Doctests ensure that the code examples continue to work as the package is changed.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [x] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
