### PR TITLE
added surface area setter and getter setter checks 

### DIFF
--- a/coxeter/shape_classes/sphere.py
+++ b/coxeter/shape_classes/sphere.py
@@ -40,7 +40,11 @@ class Sphere(Shape3D):
     """
 
     def __init__(self, radius, center=(0, 0, 0)):
-        self._radius = radius
+        if radius > 0:
+            self._radius = radius
+        else:
+            raise ValueError("Radius must be greater than zero.")
+
         self._center = np.asarray(center)
 
     @property
@@ -65,7 +69,10 @@ class Sphere(Shape3D):
 
     @radius.setter
     def radius(self, radius):
-        self._radius = radius
+        if radius > 0:
+            self._radius = radius
+        else:
+            raise ValueError("Radius must be greater than zero.")
 
     @property
     def volume(self):
@@ -74,12 +81,22 @@ class Sphere(Shape3D):
 
     @volume.setter
     def volume(self, value):
-        self._radius = (3 * value / (4 * np.pi)) ** (1 / 3)
+        if value > 0:
+            self.radius = (3 * value / (4 * np.pi)) ** (1 / 3)
+        else:
+            raise ValueError("Volume must be greater than zero.")
 
     @property
     def surface_area(self):
         """float: Get the surface area."""
         return 4 * np.pi * self.radius ** 2
+
+    @surface_area.setter
+    def surface_area(self, area):
+        if area > 0:
+            self.radius = np.sqrt(area / (4 * np.pi))
+        else:
+            raise ValueError("Surface area must be greater than zero.")
 
     @property
     def inertia_tensor(self):

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from hypothesis import given
 from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
@@ -9,11 +10,18 @@ from coxeter.shape_classes.utils import translate_inertia_tensor
 
 
 @given(floats(0.1, 1000))
-def test_get_set_radius(r):
+def test_radius_getter_setter(r):
     sphere = Sphere(r)
     assert sphere.radius == r
     sphere.radius = r + 1
     assert sphere.radius == r + 1
+
+
+@given(floats(-1000, -1))
+def test_invalid_radius_setter(r):
+    """Test setting an invalid Volume."""
+    with pytest.raises(ValueError):
+        Sphere(r)
 
 
 @given(floats(0.1, 1000))
@@ -30,6 +38,14 @@ def test_volume(r):
     assert sphere.volume == 4 / 3 * np.pi * r ** 3
 
 
+@given(floats(-1000, -1))
+def test_invalid_volume_setter(volume):
+    """Test setting an invalid Volume."""
+    sphere = Sphere(1)
+    with pytest.raises(ValueError):
+        sphere.volume = volume
+
+
 @given(floats(0.1, 1000))
 def test_set_volume(volume):
     """Test setting the volume."""
@@ -40,12 +56,20 @@ def test_set_volume(volume):
 
 
 @given(floats(0.1, 1000))
-def test_set_area(area):
+def test_area_getter_setter(area):
     """Test setting the volume."""
     sphere = Sphere(1)
     sphere.surface_area = area
     assert sphere.surface_area == approx(area)
     assert sphere.radius == approx(np.sqrt(area / (4 * np.pi)))
+
+
+@given(floats(-1000, -1))
+def test_invalid_area_setter(area):
+    """Test setting an invalid Volume."""
+    sphere = Sphere(1)
+    with pytest.raises(ValueError):
+        sphere.surface_area = area
 
 
 @given(floats(0.1, 1000))

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -9,6 +9,14 @@ from coxeter.shape_classes.utils import translate_inertia_tensor
 
 
 @given(floats(0.1, 1000))
+def test_get_set_radius(r):
+    sphere = Sphere(r)
+    assert sphere.radius == r
+    sphere.radius = r + 1
+    assert sphere.radius == r + 1
+
+
+@given(floats(0.1, 1000))
 def test_surface_area(r):
     sphere = Sphere(1)
     sphere.radius = r
@@ -29,6 +37,15 @@ def test_set_volume(volume):
     sphere.volume = volume
     assert sphere.volume == approx(volume)
     assert sphere.radius == approx((3 * volume / (4 * np.pi)) ** (1 / 3))
+
+
+@given(floats(0.1, 1000))
+def test_set_area(area):
+    """Test setting the volume."""
+    sphere = Sphere(1)
+    sphere.surface_area = area
+    assert sphere.surface_area == approx(area)
+    assert sphere.radius == approx(np.sqrt(area / (4 * np.pi)))
 
 
 @given(floats(0.1, 1000))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
added surface area setter and getter setter checks 
## Description
<!-- Describe your changes in detail -->
see summary
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
There was no surface area setter for the sphere
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
