### PR TITLE
added getter and setters for a and b

### DIFF
--- a/coxeter/shape_classes/ellipse.py
+++ b/coxeter/shape_classes/ellipse.py
@@ -47,6 +47,10 @@ class Ellipse(Shape2D):
     """
 
     def __init__(self, a, b, center=(0, 0, 0)):
+        if a <= 0:
+            raise ValueError("a must be greater than zero.")
+        if b <= 0:
+            raise ValueError("b must be greater than zero.")
         self._a = a
         self._b = b
         self._center = np.asarray(center)
@@ -73,6 +77,8 @@ class Ellipse(Shape2D):
 
     @a.setter
     def a(self, a):
+        if a <= 0:
+            raise ValueError("a must be greater than zero.")
         self._a = a
 
     @property
@@ -82,6 +88,8 @@ class Ellipse(Shape2D):
 
     @b.setter
     def b(self, b):
+        if b <= 0:
+            raise ValueError("a must be greater than zero.")
         self._b = b
 
     @property

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -19,6 +19,27 @@ def a_b_getter_setter_tests(a, b):
     assert ellipse.b == b + 1
 
 
+@given(floats(-1000, -1))
+def invalid_a_b_setter_tests(a):
+    """Check invalid a and b checks."""
+    ellipse = Ellipse(1, 1)
+    with pytest.raises(ValueError):
+        ellipse.a = a
+    with pytest.raises(ValueError):
+        ellipse.b = a
+
+
+@given(floats(-1000, -1), floats(0.1, 1000))
+def invalid_a_b_check(a, b):
+    """Check invalid a and b."""
+    with pytest.raises(ValueError):
+        Ellipse(a, b)
+    with pytest.raises(ValueError):
+        Ellipse(b, a)
+    with pytest.raises(ValueError):
+        Ellipse(a, a)
+
+
 @given(floats(0.1, 1000), floats(0.1, 1000))
 def test_perimeter(a, b):
     """Check surface area against an approximate formula."""

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -8,6 +8,18 @@ from coxeter.shape_classes.ellipse import Ellipse
 
 
 @given(floats(0.1, 1000), floats(0.1, 1000))
+def a_b_getter_setter_tests(a, b):
+    """Check getter and setter tests for a and b."""
+    ellipse = Ellipse(a, b)
+    assert ellipse.a == a
+    assert ellipse.b == b
+    ellipse.a = a + 1
+    ellipse.b = b + 1
+    assert ellipse.a == a + 1
+    assert ellipse.b == b + 1
+
+
+@given(floats(0.1, 1000), floats(0.1, 1000))
 def test_perimeter(a, b):
     """Check surface area against an approximate formula."""
     # Uses Ramanujan's approximation for the circumference of an ellipse:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Adding getters and setters for the a and b parameters of an ellipsoid. 
## Description
<!-- Describe your changes in detail -->
See summary. 
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
There were no getter or setter checks for a and b. 
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
