### PR TITLE
getter setter checks for a, b, c for a superellipsoid

### DIFF
--- a/coxeter/shape_classes/ellipsoid.py
+++ b/coxeter/shape_classes/ellipsoid.py
@@ -48,15 +48,9 @@ class Ellipsoid(Shape3D):
     """
 
     def __init__(self, a, b, c, center=(0, 0, 0)):
-        if a <= 0:
-            raise ValueError("a must be greater than zero.")
-        if b <= 0:
-            raise ValueError("b must be greater than zero.")
-        if c <= 0:
-            raise ValueError("c must be greater than zero.")
-        self._a = a
-        self._b = b
-        self._c = c
+        self.a = a
+        self.b = b
+        self.c = c
         self._center = np.asarray(center)
 
     @property

--- a/coxeter/shape_classes/ellipsoid.py
+++ b/coxeter/shape_classes/ellipsoid.py
@@ -48,6 +48,12 @@ class Ellipsoid(Shape3D):
     """
 
     def __init__(self, a, b, c, center=(0, 0, 0)):
+        if a <= 0:
+            raise ValueError("a must be greater than zero.")
+        if b <= 0:
+            raise ValueError("b must be greater than zero.")
+        if c <= 0:
+            raise ValueError("c must be greater than zero.")
         self._a = a
         self._b = b
         self._c = c
@@ -74,6 +80,8 @@ class Ellipsoid(Shape3D):
 
     @a.setter
     def a(self, a):
+        if a <= 0:
+            raise ValueError("a must be greater than zero.")
         self._a = a
 
     @property
@@ -83,6 +91,8 @@ class Ellipsoid(Shape3D):
 
     @b.setter
     def b(self, b):
+        if b <= 0:
+            raise ValueError("b must be greater than zero.")
         self._b = b
 
     @property
@@ -92,6 +102,8 @@ class Ellipsoid(Shape3D):
 
     @c.setter
     def c(self, c):
+        if c <= 0:
+            raise ValueError("c must be greater than zero.")
         self._c = c
 
     @property

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -9,6 +9,20 @@ from coxeter.shape_classes.utils import translate_inertia_tensor
 
 
 @given(floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000))
+def a_b_c_getter_setter_tests(a, b, c):
+    ellipsoid = Ellipsoid(a, b, c)
+    assert ellipsoid.a == a
+    assert ellipsoid.b == b
+    assert ellipsoid.c == c
+    ellipsoid.a = a + 1
+    ellipsoid.b = b + 1
+    ellipsoid.c = c + 1
+    assert ellipsoid.a == a + 1
+    assert ellipsoid.b == b + 1
+    assert ellipsoid.c == c + 1
+
+
+@given(floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000))
 def test_surface_area(a, b, c):
     """Check surface area against an approximate formula."""
     # Approximation from:

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -22,6 +22,27 @@ def a_b_c_getter_setter_tests(a, b, c):
     assert ellipsoid.c == c + 1
 
 
+@given(floats(-1000, -1), floats(-1000, -1), floats(-1000, -1))
+def invalid_a_b_c_setter_tests(a, b, c):
+    ellipsoid = Ellipsoid(1, 1, 1)
+    with pytest.raises(ValueError):
+        ellipsoid.a = a
+    with pytest.raises(ValueError):
+        ellipsoid.b = b
+    with pytest.raises(ValueError):
+        ellipsoid.c = c
+
+
+@given(floats(-1000, -1), floats(-1000, -1), floats(1000, 1))
+def invalid_a_b_c_tests(a, b, c):
+    with pytest.raises(ValueError):
+        Ellipsoid(a, c, c)
+    with pytest.raises(ValueError):
+        Ellipsoid(c, b, c)
+    with pytest.raises(ValueError):
+        Ellipsoid(c, c, a)
+
+
 @given(floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000))
 def test_surface_area(a, b, c):
     """Check surface area against an approximate formula."""


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Added getter and setter tests for the super-ellipsoid for a,b,c. 
## Description
<!-- Describe your changes in detail -->
Added getter and setter tests for the super-ellipsoid for a,b,c. 
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
There were no getter and setter tests for a,b,c. 
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
