### PR TITLE
Spheropolygon area setter

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -12,6 +12,7 @@ Added
 - Form factors amplitudes for sphere, polygons, and polyhedra.
 - Shape families associated with a DOI can be directly accessed via a dictionary.
 - Expected abstract interface for shapes (both 2D and 3D) has expanded.
+- Perimeter calculation for polygons.
 - Area and perimeter setters for spheropolygons.
 
 Changed

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -12,6 +12,7 @@ Added
 - Form factors amplitudes for sphere, polygons, and polyhedra.
 - Shape families associated with a DOI can be directly accessed via a dictionary.
 - Expected abstract interface for shapes (both 2D and 3D) has expanded.
+- Area and perimeter setters for spheropolygons.
 
 Changed
 ~~~~~~~

--- a/Credits.rst
+++ b/Credits.rst
@@ -48,6 +48,7 @@ Bradley Dice
 * Add ability to check if points are contained in convex spheropolyhedra.
 * Revised and edited all documentation.
 * Updated doctests to be part of pytest suite.
+* Added spheropolygon area and perimeter setters.
 
 Brandon Butler
 

--- a/coxeter/families/shape_family.py
+++ b/coxeter/families/shape_family.py
@@ -23,7 +23,7 @@ class ShapeFamily(ABC):
     a stateless class, while also providing a suitable means for using inheritance to
     create meaningful relationships between shape families. It also simplifies user
     APIs, avoiding confusing idioms like ``shape = family()(SHAPE_NAME)``. For instance,
-    given a family for generating regular polygons, the getting a hexagon should look
+    given a family for generating regular polygons, getting a hexagon should look
     roughly like ``family.get_shape(n=6)``.
     """
 

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -151,10 +151,13 @@ class ConvexSpheropolygon(Shape2D):
         return np.abs(self.signed_area)
 
     @area.setter
-    def area(self, new_area):
-        scale_factor = np.sqrt(new_area / self.area)
-        self.polygon._vertices *= scale_factor
-        self.radius *= scale_factor
+    def area(self, value):
+        if value > 0:
+            scale_factor = np.sqrt(value / self.area)
+            self.polygon._vertices *= scale_factor
+            self.radius *= scale_factor
+        else:
+            raise ValueError("Perimeter must be greater than zero.")
 
     @property
     def center(self):
@@ -169,3 +172,12 @@ class ConvexSpheropolygon(Shape2D):
     def perimeter(self):
         """float: Get the perimeter of the spheropolygon."""
         return self._polygon.perimeter + Circle(self._radius).perimeter
+
+    @perimeter.setter
+    def perimeter(self, value):
+        if value > 0:
+            scale_factor = value / self.perimeter
+            self.polygon._vertices *= scale_factor
+            self.radius *= scale_factor
+        else:
+            raise ValueError("Perimeter must be greater than zero.")

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -148,8 +148,13 @@ class ConvexSpheropolygon(Shape2D):
         To get the area, we simply compute the signed area and take the
         absolute value.
         """
-        # TODO: area setter for spheropolygon
         return np.abs(self.signed_area)
+
+    @area.setter
+    def area(self, new_area):
+        scale_factor = np.sqrt(new_area / self.area)
+        self.polygon._vertices *= scale_factor
+        self.radius *= scale_factor
 
     @property
     def center(self):

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -157,7 +157,7 @@ class ConvexSpheropolygon(Shape2D):
             self.polygon._vertices *= scale_factor
             self.radius *= scale_factor
         else:
-            raise ValueError("Perimeter must be greater than zero.")
+            raise ValueError("Area must be greater than zero.")
 
     @property
     def center(self):

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -111,7 +111,7 @@ def test_area(unit_rounded_square):
     assert shape.area == area
 
 
-@given(floats(0.1, 1000))
+@given(area=floats(0.1, 1000))
 def test_area_getter_setter(unit_rounded_square, area):
     """Test setting the area."""
     shape = unit_rounded_square
@@ -201,7 +201,7 @@ def test_sphero_square_perimeter(unit_rounded_square):
     assert unit_rounded_square.perimeter == 4 + 2 * np.pi
 
 
-@given(floats(0.1, 1000))
+@given(perimeter=floats(0.1, 1000))
 def test_perimeter_setter(unit_rounded_square, perimeter):
     """Test setting the perimeter."""
     shape = unit_rounded_square

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -5,6 +5,7 @@ import rowan
 from hypothesis import assume, example, given, settings
 from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
+from pytest import approx
 from scipy.spatial import ConvexHull
 
 from conftest import EllipseSurfaceStrategy
@@ -108,6 +109,21 @@ def test_area(unit_rounded_square):
     shape.reorder_verts(True)
     assert shape.signed_area == -area
     assert shape.area == area
+
+
+@given(floats(0.1, 1000))
+def test_area_getter_setter(unit_rounded_square, area):
+    """Test setting the volume."""
+    shape = unit_rounded_square
+    shape.area = area
+    assert shape.signed_area == approx(area)
+    assert shape.area == approx(area)
+
+    # Reset to original area
+    original_area = 1 + 4 + np.pi
+    shape.area = original_area
+    assert shape.signed_area == approx(original_area)
+    assert shape.area == approx(original_area)
 
 
 def test_center(square_points, unit_rounded_square):

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -114,16 +114,15 @@ def test_area(unit_rounded_square):
 @given(area=floats(0.1, 1000))
 def test_area_getter_setter(unit_rounded_square, area):
     """Test setting the area."""
-    shape = unit_rounded_square
-    shape.area = area
-    assert shape.signed_area == approx(area)
-    assert shape.area == approx(area)
+    unit_rounded_square.area = area
+    assert unit_rounded_square.signed_area == approx(area)
+    assert unit_rounded_square.area == approx(area)
 
     # Reset to original area
     original_area = 1 + 4 + np.pi
-    shape.area = original_area
-    assert shape.signed_area == approx(original_area)
-    assert shape.area == approx(original_area)
+    unit_rounded_square.area = original_area
+    assert unit_rounded_square.signed_area == approx(original_area)
+    assert unit_rounded_square.area == approx(original_area)
 
 
 def test_center(square_points, unit_rounded_square):
@@ -204,12 +203,11 @@ def test_sphero_square_perimeter(unit_rounded_square):
 @given(perimeter=floats(0.1, 1000))
 def test_perimeter_setter(unit_rounded_square, perimeter):
     """Test setting the perimeter."""
-    shape = unit_rounded_square
-    shape.perimeter = perimeter
-    assert shape.perimeter == approx(perimeter)
+    unit_rounded_square.perimeter = perimeter
+    assert unit_rounded_square.perimeter == approx(perimeter)
 
     # Reset to original perimeter
     original_perimeter = 4 + 2 * np.pi
-    shape.perimeter = original_perimeter
-    assert shape.perimeter == approx(original_perimeter)
-    assert shape.radius == approx(1.0)
+    unit_rounded_square.perimeter = original_perimeter
+    assert unit_rounded_square.perimeter == approx(original_perimeter)
+    assert unit_rounded_square.radius == approx(1.0)

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -113,7 +113,7 @@ def test_area(unit_rounded_square):
 
 @given(floats(0.1, 1000))
 def test_area_getter_setter(unit_rounded_square, area):
-    """Test setting the volume."""
+    """Test setting the area."""
     shape = unit_rounded_square
     shape.area = area
     assert shape.signed_area == approx(area)
@@ -199,3 +199,17 @@ def test_convex_signed_area(square_points):
 def test_sphero_square_perimeter(unit_rounded_square):
     """Test calculating the perimeter of a spheropolygon."""
     assert unit_rounded_square.perimeter == 4 + 2 * np.pi
+
+
+@given(floats(0.1, 1000))
+def test_perimeter_setter(unit_rounded_square, perimeter):
+    """Test setting the perimeter."""
+    shape = unit_rounded_square
+    shape.perimeter = perimeter
+    assert shape.perimeter == approx(perimeter)
+
+    # Reset to original perimeter
+    original_perimeter = 4 + 2 * np.pi
+    shape.perimeter = original_perimeter
+    assert shape.perimeter == approx(original_perimeter)
+    assert shape.radius == approx(1.0)


### PR DESCRIPTION
## Description
This resolves a TODO item in the code by adding a setter method for spheropolygon area and perimeter.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
