### PR TITLE
Fix test names

### DIFF
--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -8,8 +8,8 @@ from coxeter.shapes.ellipse import Ellipse
 
 
 @given(floats(0.1, 1000), floats(0.1, 1000))
-def a_b_getter_setter_tests(a, b):
-    """Check getter and setter tests for a and b."""
+def test_a_b_getter_setter(a, b):
+    """Test getter and setter for a and b."""
     ellipse = Ellipse(a, b)
     assert ellipse.a == a
     assert ellipse.b == b
@@ -20,8 +20,8 @@ def a_b_getter_setter_tests(a, b):
 
 
 @given(floats(-1000, -1))
-def invalid_a_b_setter_tests(a):
-    """Check invalid a and b checks."""
+def test_invalid_a_b_setter(a):
+    """Test setting invalid a, b values."""
     ellipse = Ellipse(1, 1)
     with pytest.raises(ValueError):
         ellipse.a = a
@@ -30,8 +30,8 @@ def invalid_a_b_setter_tests(a):
 
 
 @given(floats(-1000, -1), floats(0.1, 1000))
-def invalid_a_b_check(a, b):
-    """Check invalid a and b."""
+def test_invalid_a_b_constructor(a, b):
+    """Test invalid a, b values in constructor."""
     with pytest.raises(ValueError):
         Ellipse(a, b)
     with pytest.raises(ValueError):

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -9,7 +9,8 @@ from coxeter.shapes.utils import translate_inertia_tensor
 
 
 @given(floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000))
-def a_b_c_getter_setter_tests(a, b, c):
+def test_a_b_c_getter_setter(a, b, c):
+    """Test getter and setter for a, b, and c."""
     ellipsoid = Ellipsoid(a, b, c)
     assert ellipsoid.a == a
     assert ellipsoid.b == b
@@ -22,25 +23,28 @@ def a_b_c_getter_setter_tests(a, b, c):
     assert ellipsoid.c == c + 1
 
 
-@given(floats(-1000, -1), floats(-1000, -1), floats(-1000, -1))
-def invalid_a_b_c_setter_tests(a, b, c):
+@given(floats(-1000, -1))
+def test_invalid_a_b_c_setter(a):
+    """Test setting invalid a, b, c values."""
+    # a is invalid
     ellipsoid = Ellipsoid(1, 1, 1)
     with pytest.raises(ValueError):
         ellipsoid.a = a
     with pytest.raises(ValueError):
-        ellipsoid.b = b
+        ellipsoid.b = a
     with pytest.raises(ValueError):
-        ellipsoid.c = c
+        ellipsoid.c = a
 
 
-@given(floats(-1000, -1), floats(-1000, -1), floats(1000, 1))
-def invalid_a_b_c_tests(a, b, c):
+@given(floats(-1000, -1), floats(0.1, 1000), floats(0.1, 1000))
+def test_invalid_a_b_c_constructor(a, b, c):
+    """Test invalid a, b, c values in constructor."""
     with pytest.raises(ValueError):
-        Ellipsoid(a, c, c)
+        Ellipsoid(a, b, c)
     with pytest.raises(ValueError):
-        Ellipsoid(c, b, c)
+        Ellipsoid(c, a, b)
     with pytest.raises(ValueError):
-        Ellipsoid(c, c, a)
+        Ellipsoid(b, c, a)
 
 
 @given(floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000))

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -37,7 +37,7 @@ def test_2d_verts(square_points):
 
 
 @given(floats(0.1, 1000))
-def test_radius_getter_setter(r, square_points):
+def test_radius_getter_setter(square_points, r):
     """Test getting and setting the radius."""
     square_points = square_points[:, :2]
     convexspheropolygon = ConvexSpheropolygon(square_points, r)

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -50,7 +50,7 @@ def test_radius_getter_setter(r, square_points):
 
 @given(floats(-1000, -1))
 def test_invalid_radius_constructor(square_points, r):
-    """Test getting and setting the radius."""
+    """Test invalid radius values in constructor."""
     square_points = square_points[:, :2]
     with pytest.raises(ValueError):
         ConvexSpheropolygon(square_points, r)
@@ -58,7 +58,7 @@ def test_invalid_radius_constructor(square_points, r):
 
 @given(floats(-1000, -1))
 def test_invalid_radius_setter(square_points, r):
-    """Test getting and setting the radius."""
+    """Test setting invalid radius values."""
     square_points = square_points[:, :2]
     spheropolygon = ConvexSpheropolygon(square_points, 1)
     with pytest.raises(ValueError):

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -36,7 +36,7 @@ def test_2d_verts(square_points):
     ConvexSpheropolygon(square_points, 1)
 
 
-@given(floats(0.1, 1000))
+@given(r=floats(0.1, 1000))
 def test_radius_getter_setter(square_points, r):
     """Test getting and setting the radius."""
     square_points = square_points[:, :2]
@@ -46,7 +46,7 @@ def test_radius_getter_setter(square_points, r):
     assert convexspheropolygon.radius == r + 1
 
 
-@given(floats(-1000, -1))
+@given(r=floats(-1000, -1))
 def test_invalid_radius_constructor(square_points, r):
     """Test invalid radius values in constructor."""
     square_points = square_points[:, :2]
@@ -54,7 +54,7 @@ def test_invalid_radius_constructor(square_points, r):
         ConvexSpheropolygon(square_points, r)
 
 
-@given(floats(-1000, -1))
+@given(r=floats(-1000, -1))
 def test_invalid_radius_setter(square_points, r):
     """Test setting invalid radius values."""
     square_points = square_points[:, :2]

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -37,7 +37,7 @@ def test_2d_verts(square_points):
 
 
 @given(floats(0.1, 1000))
-def radius_getter_setter_tests(r, square_points):
+def test_radius_getter_setter(r, square_points):
     """Test getting and setting the radius."""
     square_points = square_points[:, :2]
     convexspheropolygon = ConvexSpheropolygon(square_points, r)
@@ -49,7 +49,7 @@ def radius_getter_setter_tests(r, square_points):
 
 
 @given(floats(-1000, -1))
-def invalid_radius_tests(r, square_points):
+def test_invalid_radius_constructor(square_points, r):
     """Test getting and setting the radius."""
     square_points = square_points[:, :2]
     with pytest.raises(ValueError):
@@ -57,7 +57,7 @@ def invalid_radius_tests(r, square_points):
 
 
 @given(floats(-1000, -1))
-def invalid_radius_setter_tests(r, square_points):
+def test_invalid_radius_setter(square_points, r):
     """Test getting and setting the radius."""
     square_points = square_points[:, :2]
     spheropolygon = ConvexSpheropolygon(square_points, 1)

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -44,8 +44,6 @@ def test_radius_getter_setter(square_points, r):
     assert convexspheropolygon.radius == r
     convexspheropolygon.radius = r + 1
     assert convexspheropolygon.radius == r + 1
-    with pytest.raises(ValueError):
-        convexspheropolygon.radius = "invalid value"
 
 
 @given(floats(-1000, -1))


### PR DESCRIPTION
## Description
Some tests weren't running because they were incorrectly named. @Tobias-Dwyer FYI, test functions have to start with the word `test_...`. I also fixed an issue with fixtures and `@given` (the argument order had to be swapped -- fixtures should go first and `@given` parameters go second).

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
