### PR TITLE
Create axes for plotting if not provided.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -12,6 +12,7 @@ Added
 - Form factors amplitudes for sphere, polygons, and polyhedra.
 - Shape families associated with a DOI can be directly accessed via a dictionary.
 - Expected abstract interface for shapes (both 2D and 3D) has expanded.
+- Plotting polygons or polyhedra can automatically create matplotlib axes.
 
 Changed
 ~~~~~~~

--- a/Credits.rst
+++ b/Credits.rst
@@ -48,6 +48,7 @@ Bradley Dice
 * Add ability to check if points are contained in convex spheropolyhedra.
 * Revised and edited all documentation.
 * Updated doctests to be part of pytest suite.
+* Added automatic axis creation for plotting.
 
 Brandon Butler
 

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -78,6 +78,10 @@ class Shape(ABC):
             "The form factor calculation is not implemented for this shape."
         )
 
+    def plot(self):
+        """Plot the shape."""
+        raise NotImplementedError("Plotting is not implemented for this shape.")
+
 
 class Shape2D(Shape):
     """An abstract representation of a shape in 2 dimensions."""

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -7,7 +7,7 @@ from ..bentley_ottmann import poly_point_isect
 from ..polytri import polytri
 from .base_classes import Shape2D
 from .circle import Circle
-from .utils import rotate_order2_tensor, translate_inertia_tensor
+from .utils import rotate_order2_tensor, translate_inertia_tensor, _generate_ax
 
 try:
     import miniball
@@ -430,7 +430,7 @@ class Polygon(Shape2D):
         """
         yield from polytri.triangulate(self.vertices)
 
-    def plot(self, ax, center=False, plot_verts=False, label_verts=False):
+    def plot(self, ax=None, center=False, plot_verts=False, label_verts=False):
         """Plot the polygon.
 
         Note that the polygon is always rotated into the :math:`xy` plane and
@@ -438,7 +438,8 @@ class Polygon(Shape2D):
 
         Args:
             ax (:class:`matplotlib.axes.Axes`):
-                The axes on which to draw the polygon.
+                The axes on which to draw the polygon. Axes will be created
+                if this is None (Default value: None).
             center (bool):
                 If True, the polygon vertices are plotted relative to its
                 center (Default value: False).
@@ -449,7 +450,7 @@ class Polygon(Shape2D):
                 If True, vertex indices will be added next to the vertices
                 (Default value: False).
         """
-        # TODO: Generate axis if one is not provided.
+        ax = _generate_ax(ax)
         verts = self._vertices - self.center if center else self._vertices
         verts = _align_points_by_normal(self._normal, verts)
         verts = np.concatenate((verts, verts[[0]]))

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -7,7 +7,7 @@ from ..bentley_ottmann import poly_point_isect
 from ..polytri import polytri
 from .base_classes import Shape2D
 from .circle import Circle
-from .utils import rotate_order2_tensor, translate_inertia_tensor, _generate_ax
+from .utils import _generate_ax, rotate_order2_tensor, translate_inertia_tensor
 
 try:
     import miniball

--- a/coxeter/shapes/polyhedron.py
+++ b/coxeter/shapes/polyhedron.py
@@ -8,7 +8,7 @@ from .base_classes import Shape3D
 from .convex_polygon import ConvexPolygon, _is_convex
 from .polygon import Polygon, _is_simple
 from .sphere import Sphere
-from .utils import translate_inertia_tensor, _generate_ax, _set_3d_axes_equal
+from .utils import _generate_ax, _set_3d_axes_equal, translate_inertia_tensor
 
 try:
     import miniball

--- a/coxeter/shapes/polyhedron.py
+++ b/coxeter/shapes/polyhedron.py
@@ -8,7 +8,7 @@ from .base_classes import Shape3D
 from .convex_polygon import ConvexPolygon, _is_convex
 from .polygon import Polygon, _is_simple
 from .sphere import Sphere
-from .utils import translate_inertia_tensor
+from .utils import translate_inertia_tensor, _generate_ax, _set_3d_axes_equal
 
 try:
     import miniball
@@ -555,7 +555,7 @@ class Polyhedron(Shape3D):
         n1, n2 = self._equations[[a, b], :3]
         return np.arccos(np.dot(-n1, n2))
 
-    def plot(self, ax, plot_verts=False, label_verts=False):
+    def plot(self, ax=None, plot_verts=False, label_verts=False):
         """Plot the polyhedron.
 
         Note that the ``ax`` argument should be a 3D axes object; passing in
@@ -563,7 +563,8 @@ class Polyhedron(Shape3D):
 
         Args:
             ax (:class:`mpl_toolkits.mplot3d.axes3d.Axes3D`):
-                The axes on which to draw the polyhedron.
+                The axes on which to draw the polyhedron. Axes will be
+                created if this is None (Default value: None).
             plot_verts (bool):
                 If True, scatter points will be added at the vertices
                 (Default value: False).
@@ -571,7 +572,8 @@ class Polyhedron(Shape3D):
                 If True, vertex indices will be added next to the vertices
                 (Default value: False).
         """
-        # TODO: Generate axis if one is not provided.
+        ax = _generate_ax(ax, axes3d=True)
+
         # Determine dimensionality.
         for face in self.faces:
             verts = self.vertices[face]
@@ -585,6 +587,7 @@ class Polyhedron(Shape3D):
             shift = (np.max(self.vertices[:, 2]) - np.min(self.vertices[:, 2])) * 0.025
             for i, vert in enumerate(self.vertices):
                 ax.text(vert[0], vert[1], vert[2] + shift, "{}".format(i), fontsize=10)
+        _set_3d_axes_equal(ax)
 
     def diagonalize_inertia(self):
         """Orient the shape along its principal axes.

--- a/coxeter/shapes/utils.py
+++ b/coxeter/shapes/utils.py
@@ -43,7 +43,6 @@ def _generate_ax(ax=None, axes3d=False):
     if ax is None:
         try:
             import matplotlib.pyplot as plt
-            from matplotlib.backends.backend_agg import FigureCanvasAgg
         except ImportError:
             raise ImportError("matplotlib must be installed for plotting.")
         fig = plt.figure()
@@ -59,17 +58,19 @@ def _generate_ax(ax=None, axes3d=False):
 
 
 def _set_3d_axes_equal(ax, limits=None):
-    """Make axes of 3D plot have equal scale so that spheres appear as spheres,
-    cubes as cubes, etc. This is one possible solution to Matplotlib's
+    """Make axes of 3D plot have equal scale.
+
+    Ensuring equal scale means that spheres appear as spheres, cubes as
+    cubes, etc. This is one possible solution to Matplotlib's
     ax.set_aspect('equal') and ax.axis('equal') not working for 3D.
 
     Args:
-        ax (:class:`matplotlib.axes.Axes`): Axes object.
+        ax (:class:`matplotlib.axes.Axes`):
+            Axes object.
         limits (:math:`(3, 2)` :class:`np.ndarray`):
-            Axis limits in the form
-            :code:`[[xmin, xmax], [ymin, ymax], [zmin, zmax]]`. If
-            :code:`None`, the limits are auto-detected (Default value =
-            :code:`None`).
+            Axis limits in the form :code:`[[xmin, xmax], [ymin, ymax],
+            [zmin, zmax]]`. If :code:`None`, the limits are auto-detected
+            (Default value = :code:`None`).
     """
     # Adapted from https://stackoverflow.com/a/50664367
 

--- a/coxeter/shapes/utils.py
+++ b/coxeter/shapes/utils.py
@@ -22,3 +22,64 @@ def translate_inertia_tensor(displacement, inertia_tensor, volume):
 def rotate_order2_tensor(rotation, tensor):
     """Transform a tensor with a similarity transformation."""
     return rotation @ tensor @ rotation.T
+
+
+def _generate_ax(ax=None, axes3d=False):
+    """Create an instance of :class:`matplotlib.axes.Axes` if needed.
+
+    If an instance of :class:`matplotlib.axes.Axes` is provided, it will be
+    passed through.
+
+    Args:
+        ax (:class:`matplotlib.axes.Axes`):
+            The axes on which to draw the polygon. An instance will be
+            created if this is None (Default value: None).
+        axes3d (bool):
+            Whether to use 3D axes (Default value: False).
+
+    Returns:
+        :class:`matplotlib.axes.Axes`: Axes to plot on.
+    """
+    if ax is None:
+        try:
+            import matplotlib.pyplot as plt
+            from matplotlib.backends.backend_agg import FigureCanvasAgg
+        except ImportError:
+            raise ImportError("matplotlib must be installed for plotting.")
+        fig = plt.figure()
+        if not axes3d:
+            ax = fig.subplots()
+            ax.set_aspect("equal", "datalim")
+        else:
+            # This import registers the 3d projection
+            from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+
+            ax = fig.add_subplot(111, projection="3d")
+    return ax
+
+
+def _set_3d_axes_equal(ax, limits=None):
+    """Make axes of 3D plot have equal scale so that spheres appear as spheres,
+    cubes as cubes, etc. This is one possible solution to Matplotlib's
+    ax.set_aspect('equal') and ax.axis('equal') not working for 3D.
+
+    Args:
+        ax (:class:`matplotlib.axes.Axes`): Axes object.
+        limits (:math:`(3, 2)` :class:`np.ndarray`):
+            Axis limits in the form
+            :code:`[[xmin, xmax], [ymin, ymax], [zmin, zmax]]`. If
+            :code:`None`, the limits are auto-detected (Default value =
+            :code:`None`).
+    """
+    # Adapted from https://stackoverflow.com/a/50664367
+
+    if limits is None:
+        limits = np.array([ax.get_xlim3d(), ax.get_ylim3d(), ax.get_zlim3d()])
+    else:
+        limits = np.asarray(limits)
+    origin = np.mean(limits, axis=1)
+    radius = 0.5 * np.max(limits[:, 1] - limits[:, 0])
+    ax.set_xlim3d([origin[0] - radius, origin[0] + radius])
+    ax.set_ylim3d([origin[1] - radius, origin[1] + radius])
+    ax.set_zlim3d([origin[2] - radius, origin[2] + radius])
+    return ax


### PR DESCRIPTION
## Description
Axis objects can be created automatically when plotting polygons / polyhedra.

## Motivation and Context
Resolves TODO items. This copies some code that I wrote for freud.
![image](https://user-images.githubusercontent.com/3943761/95798560-f726dd80-0cb7-11eb-84ae-b8976ef0688e.png)

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
