### PR TITLE
Make a Python 3 wheel, not a universal wheel.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ tag = True
 message = Bump up to version {new_version}.
 
 [bdist_wheel]
-universal = 1
+python-tag = py3
 
 [bumpversion:file:coxeter/__init__.py]
 


### PR DESCRIPTION
## Description
Coxeter isn't compatible with Python 2. Thus, we can't create a "universal" wheel. Instead, we need to use a Python 3 tag.
https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels

@vyasr You could consider deleting the previous wheel for 0.4.0 and re-generating a wheel with this fix. (Or you can decide that it doesn't matter.)

## Motivation and Context
Fixes wheel compatibility.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
