### PR TITLE
More consistent setters

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,13 @@
 The format is based on `Keep a Changelog <http://keepachangelog.com/en/1.0.0/>`__.
 This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`__.
 
+next
+----
+
+Added
+~~~~~
+
+- Ellipse area setter and Ellipsoid volume setter.
 
 v0.4.0 - 2020-10-14
 -------------------

--- a/Credits.rst
+++ b/Credits.rst
@@ -50,6 +50,7 @@ Bradley Dice
 * Updated doctests to be part of pytest suite.
 * Added automatic axis creation for plotting.
 * Added spheropolygon area and perimeter setters.
+* Added ellipse area setter and ellipsoid volume setter.
 
 Brandon Butler
 

--- a/coxeter/shapes/circle.py
+++ b/coxeter/shapes/circle.py
@@ -62,9 +62,9 @@ class Circle(Shape2D):
         return self._radius
 
     @radius.setter
-    def radius(self, r):
-        if r > 0:
-            self._radius = r
+    def radius(self, value):
+        if value > 0:
+            self._radius = value
         else:
             raise ValueError("Radius must be greater than zero.")
 

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -164,8 +164,8 @@ class ConvexSpheropolygon(Shape2D):
         return self._polygon.center
 
     @center.setter
-    def center(self, new_center):
-        self._polygon.center = new_center
+    def center(self, value):
+        self._polygon.center = value
 
     @property
     def perimeter(self):

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -119,7 +119,7 @@ class ConvexSpheropolygon(Shape2D):
         if value >= 0:
             self._radius = value
         else:
-            raise ValueError("Radius must be greater or equal to zero.")
+            raise ValueError("Radius must be greater than or equal to zero.")
 
     @property
     def signed_area(self):

--- a/coxeter/shapes/convex_spheropolyhedron.py
+++ b/coxeter/shapes/convex_spheropolyhedron.py
@@ -138,7 +138,7 @@ class ConvexSpheropolyhedron(Shape3D):
 
     @radius.setter
     def radius(self, value):
-        if radius >= 0:
+        if value >= 0:
             self._radius = value
         else:
             raise ValueError("Rounding radius must be greater than or equal to zero.")

--- a/coxeter/shapes/convex_spheropolyhedron.py
+++ b/coxeter/shapes/convex_spheropolyhedron.py
@@ -98,8 +98,8 @@ class ConvexSpheropolyhedron(Shape3D):
         return self._polyhedron.center
 
     @center.setter
-    def center(self, new_center):
-        self._polyhedron.center = new_center
+    def center(self, value):
+        self._polyhedron.center = value
 
     @property
     def volume(self):
@@ -137,9 +137,9 @@ class ConvexSpheropolyhedron(Shape3D):
         return self._radius
 
     @radius.setter
-    def radius(self, radius):
+    def radius(self, value):
         if radius >= 0:
-            self._radius = radius
+            self._radius = value
         else:
             raise ValueError("Rounding radius must be greater than or equal to zero.")
 

--- a/coxeter/shapes/ellipse.py
+++ b/coxeter/shapes/ellipse.py
@@ -75,10 +75,11 @@ class Ellipse(Shape2D):
         return self._a
 
     @a.setter
-    def a(self, a):
-        if a <= 0:
+    def a(self, value):
+        if value > 0:
+            self._a = value
+        else:
             raise ValueError("a must be greater than zero.")
-        self._a = a
 
     @property
     def b(self):
@@ -86,10 +87,11 @@ class Ellipse(Shape2D):
         return self._b
 
     @b.setter
-    def b(self, b):
-        if b <= 0:
-            raise ValueError("a must be greater than zero.")
-        self._b = b
+    def b(self, value):
+        if value > 0:
+            self._b = value
+        else:
+            raise ValueError("b must be greater than zero.")
 
     @property
     def area(self):

--- a/coxeter/shapes/ellipse.py
+++ b/coxeter/shapes/ellipse.py
@@ -98,6 +98,15 @@ class Ellipse(Shape2D):
         """float: The area."""
         return np.pi * self.a * self.b
 
+    @area.setter
+    def area(self, value):
+        if value > 0:
+            scale_factor = np.sqrt(value / self.area)
+            self.a *= scale_factor
+            self.b *= scale_factor
+        else:
+            raise ValueError("Area must be greater than zero.")
+
     @property
     def eccentricity(self):
         """float: The eccentricity."""

--- a/coxeter/shapes/ellipsoid.py
+++ b/coxeter/shapes/ellipsoid.py
@@ -110,6 +110,16 @@ class Ellipsoid(Shape3D):
         """float: Get the volume."""
         return (4 / 3) * np.pi * self.a * self.b * self.c
 
+    @volume.setter
+    def volume(self, value):
+        if value > 0:
+            scale_factor = np.cbrt(value / self.volume)
+            self.a *= scale_factor
+            self.b *= scale_factor
+            self.c *= scale_factor
+        else:
+            raise ValueError("Volume must be greater than zero.")
+
     @property
     def surface_area(self):
         """float: Get the surface area."""

--- a/coxeter/shapes/ellipsoid.py
+++ b/coxeter/shapes/ellipsoid.py
@@ -75,10 +75,11 @@ class Ellipsoid(Shape3D):
         return self._a
 
     @a.setter
-    def a(self, a):
-        if a <= 0:
+    def a(self, value):
+        if value > 0:
+            self._a = value
+        else:
             raise ValueError("a must be greater than zero.")
-        self._a = a
 
     @property
     def b(self):
@@ -86,10 +87,11 @@ class Ellipsoid(Shape3D):
         return self._b
 
     @b.setter
-    def b(self, b):
-        if b <= 0:
+    def b(self, value):
+        if value > 0:
+            self._b = value
+        else:
             raise ValueError("b must be greater than zero.")
-        self._b = b
 
     @property
     def c(self):
@@ -97,10 +99,11 @@ class Ellipsoid(Shape3D):
         return self._c
 
     @c.setter
-    def c(self, c):
-        if c <= 0:
+    def c(self, value):
+        if value > 0:
+            self._c = value
+        else:
             raise ValueError("c must be greater than zero.")
-        self._c = c
 
     @property
     def volume(self):

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -299,8 +299,8 @@ class Polygon(Shape2D):
         return np.abs(self.signed_area)
 
     @area.setter
-    def area(self, new_area):
-        scale_factor = np.sqrt(new_area / self.area)
+    def area(self, value):
+        scale_factor = np.sqrt(value / self.area)
         self._vertices *= scale_factor
 
     @property

--- a/coxeter/shapes/polyhedron.py
+++ b/coxeter/shapes/polyhedron.py
@@ -351,8 +351,8 @@ class Polyhedron(Shape3D):
         return np.sum(ds * self.get_face_area()) / 3
 
     @volume.setter
-    def volume(self, new_volume):
-        scale_factor = (new_volume / self.volume) ** (1 / 3)
+    def volume(self, value):
+        scale_factor = (value / self.volume) ** (1 / 3)
         self._vertices *= scale_factor
         self._equations[:, 3] *= scale_factor
 

--- a/coxeter/shapes/sphere.py
+++ b/coxeter/shapes/sphere.py
@@ -59,9 +59,9 @@ class Sphere(Shape3D):
         return self._radius
 
     @radius.setter
-    def radius(self, radius):
-        if radius > 0:
-            self._radius = radius
+    def radius(self, value):
+        if value > 0:
+            self._radius = value
         else:
             raise ValueError("Radius must be greater than zero.")
 
@@ -83,9 +83,9 @@ class Sphere(Shape3D):
         return 4 * np.pi * self.radius ** 2
 
     @surface_area.setter
-    def surface_area(self, area):
-        if area > 0:
-            self.radius = np.sqrt(area / (4 * np.pi))
+    def surface_area(self, value):
+        if value > 0:
+            self.radius = np.sqrt(value / (4 * np.pi))
         else:
             raise ValueError("Surface area must be greater than zero.")
 

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -3,6 +3,7 @@ import pytest
 from hypothesis import given
 from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
+from pytest import approx
 
 from coxeter.shapes.ellipse import Ellipse
 
@@ -59,6 +60,21 @@ def test_area(a, b):
     ellipse.a = a
     ellipse.b = b
     assert ellipse.area == np.pi * a * b
+
+
+@given(floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000))
+def test_set_area(a, b, area):
+    """Test setting the area."""
+    ellipse = Ellipse(a, b)
+    original_area = ellipse.area
+    ellipse.area = area
+    assert ellipse.area == approx(area)
+
+    # Reset to original area
+    ellipse.area = original_area
+    assert ellipse.area == approx(original_area)
+    assert ellipse.a == approx(a)
+    assert ellipse.b == approx(b)
 
 
 @given(floats(0.1, 1000), floats(0.1, 1000))

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -3,6 +3,7 @@ import pytest
 from hypothesis import given
 from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
+from pytest import approx
 
 from coxeter.shapes.ellipsoid import Ellipsoid
 from coxeter.shapes.utils import translate_inertia_tensor
@@ -70,6 +71,22 @@ def test_volume(a, b, c):
     ellipsoid.b = b
     ellipsoid.c = c
     assert ellipsoid.volume == 4 / 3 * np.pi * a * b * c
+
+
+@given(floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000))
+def test_set_volume(a, b, c, volume):
+    """Test setting the volume."""
+    ellipsoid = Ellipsoid(a, b, c)
+    original_volume = ellipsoid.volume
+    ellipsoid.volume = volume
+    assert ellipsoid.volume == approx(volume)
+
+    # Reset to original volume
+    ellipsoid.volume = original_volume
+    assert ellipsoid.volume == approx(original_volume)
+    assert ellipsoid.a == approx(a)
+    assert ellipsoid.b == approx(b)
+    assert ellipsoid.c == approx(c)
 
 
 def test_earth():


### PR DESCRIPTION
## Description
I made property setters look the same:
- Input parameter is named `value`.
- Property setting logic is always first (`if value > 0:`), error raising is always second (`else: raise`). This is my preference because it ensures the expected path is first (easier to read) and the condition matches the error message text (`if value > 0` matches the error `Value must be greater than zero.` and is thus easier to think through).

I also added setters for ellipse area and ellipsoid volume. (I specifically needed ellipsoid volume but wanted ellipse area to match.)

## Motivation and Context
Resolves #114. I did not know the issue already existed and had been assigned to @Tobias-Dwyer, I just wanted to add the volume setter for ellipsoids and figured I'd improve the code base at the same time.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
