### PR TITLE
Add _rescale for use with setters.

### DIFF
--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -20,6 +20,16 @@ class Shape(ABC):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501
         pass
 
+    @abstractmethod
+    def _rescale(self, scale):
+        """Multiply length scale.
+
+        Args:
+            scale (float):
+                Scale factor.
+        """
+        pass
+
     @property
     def gsd_shape_spec(self):
         """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401

--- a/coxeter/shapes/circle.py
+++ b/coxeter/shapes/circle.py
@@ -68,6 +68,15 @@ class Circle(Shape2D):
         else:
             raise ValueError("Radius must be greater than zero.")
 
+    def _rescale(self, scale):
+        """Multiply length scale.
+
+        Args:
+            scale (float):
+                Scale factor.
+        """
+        self.radius *= scale
+
     @property
     def area(self):
         """float: Get the area of the circle."""

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -120,6 +120,16 @@ class ConvexSpheropolygon(Shape2D):
         else:
             raise ValueError("Radius must be greater than or equal to zero.")
 
+    def _rescale(self, scale):
+        """Multiply length scale.
+
+        Args:
+            scale (float):
+                Scale factor.
+        """
+        self.polygon._vertices *= scale
+        self.radius *= scale
+
     @property
     def signed_area(self):
         """Get the signed area of the spheropolygon.
@@ -151,9 +161,8 @@ class ConvexSpheropolygon(Shape2D):
     @area.setter
     def area(self, value):
         if value > 0:
-            scale_factor = np.sqrt(value / self.area)
-            self.polygon._vertices *= scale_factor
-            self.radius *= scale_factor
+            scale = np.sqrt(value / self.area)
+            self._rescale(scale)
         else:
             raise ValueError("Area must be greater than zero.")
 
@@ -174,8 +183,7 @@ class ConvexSpheropolygon(Shape2D):
     @perimeter.setter
     def perimeter(self, value):
         if value > 0:
-            scale_factor = value / self.perimeter
-            self.polygon._vertices *= scale_factor
-            self.radius *= scale_factor
+            scale = value / self.perimeter
+            self._rescale(scale)
         else:
             raise ValueError("Perimeter must be greater than zero.")

--- a/coxeter/shapes/convex_spheropolyhedron.py
+++ b/coxeter/shapes/convex_spheropolyhedron.py
@@ -101,6 +101,16 @@ class ConvexSpheropolyhedron(Shape3D):
     def center(self, value):
         self.polyhedron.center = value
 
+    def _rescale(self, scale):
+        """Multiply length scale.
+
+        Args:
+            scale (float):
+                Scale factor.
+        """
+        self.polyhedron._rescale(scale)
+        self.radius *= scale
+
     @property
     def volume(self):
         """float: The volume."""
@@ -130,6 +140,11 @@ class ConvexSpheropolyhedron(Shape3D):
             v_cyl += (np.pi * self.radius ** 2) * (phi / (2 * np.pi)) * edge_length
 
         return v_poly + v_sphere + v_face + v_cyl
+
+    @volume.setter
+    def volume(self, value):
+        scale = (value / self.volume) ** (1 / 3)
+        self._rescale(scale)
 
     @property
     def radius(self):
@@ -169,6 +184,14 @@ class ConvexSpheropolyhedron(Shape3D):
             a_cyl += (2 * np.pi * self.radius) * (phi / (2 * np.pi)) * edge_length
 
         return a_poly + a_sphere + a_cyl
+
+    @surface_area.setter
+    def surface_area(self, value):
+        if value > 0:
+            scale = np.sqrt(value / self.surface_area)
+            self._rescale(scale)
+        else:
+            raise ValueError("Surface area must be greater than zero.")
 
     def is_inside(self, points):
         """Determine whether points are contained in this spheropolyhedron.

--- a/coxeter/shapes/ellipse.py
+++ b/coxeter/shapes/ellipse.py
@@ -89,6 +89,16 @@ class Ellipse(Shape2D):
         else:
             raise ValueError("b must be greater than zero.")
 
+    def _rescale(self, scale):
+        """Multiply length scale.
+
+        Args:
+            scale (float):
+                Scale factor.
+        """
+        self.a *= scale
+        self.b *= scale
+
     @property
     def area(self):
         """float: Get or set the area."""
@@ -97,9 +107,8 @@ class Ellipse(Shape2D):
     @area.setter
     def area(self, value):
         if value > 0:
-            scale_factor = np.sqrt(value / self.area)
-            self.a *= scale_factor
-            self.b *= scale_factor
+            scale = np.sqrt(value / self.area)
+            self._rescale(scale)
         else:
             raise ValueError("Area must be greater than zero.")
 
@@ -126,10 +135,22 @@ class Ellipse(Shape2D):
         result = 4 * a * ellipe(self.eccentricity ** 2)
         return result
 
+    @perimeter.setter
+    def perimeter(self, value):
+        if value > 0:
+            scale = value / self.perimeter
+            self._rescale(scale)
+        else:
+            raise ValueError("Perimeter must be greater than zero.")
+
     @property
     def circumference(self):
         """float: Alias for `Ellipse.perimeter`."""
         return self.perimeter
+
+    @circumference.setter
+    def circumference(self, value):
+        self.perimeter = value
 
     @property
     def planar_moments_inertia(self):

--- a/coxeter/shapes/ellipsoid.py
+++ b/coxeter/shapes/ellipsoid.py
@@ -105,6 +105,17 @@ class Ellipsoid(Shape3D):
         else:
             raise ValueError("c must be greater than zero.")
 
+    def _rescale(self, scale):
+        """Multiply length scale.
+
+        Args:
+            scale (float):
+                Scale factor.
+        """
+        self.a *= scale
+        self.b *= scale
+        self.c *= scale
+
     @property
     def volume(self):
         """float: Get or set the volume."""
@@ -113,10 +124,8 @@ class Ellipsoid(Shape3D):
     @volume.setter
     def volume(self, value):
         if value > 0:
-            scale_factor = np.cbrt(value / self.volume)
-            self.a *= scale_factor
-            self.b *= scale_factor
-            self.c *= scale_factor
+            scale = np.cbrt(value / self.volume)
+            self._rescale(scale)
         else:
             raise ValueError("Volume must be greater than zero.")
 
@@ -138,6 +147,14 @@ class Ellipsoid(Shape3D):
 
         result = 2 * np.pi * (c ** 2 + a * b * elliptic_part)
         return result
+
+    @surface_area.setter
+    def surface_area(self, value):
+        if value > 0:
+            scale = np.sqrt(value / self.surface_area)
+            self._rescale(scale)
+        else:
+            raise ValueError("Surface area must be greater than zero.")
 
     @property
     def inertia_tensor(self):

--- a/coxeter/shapes/polyhedron.py
+++ b/coxeter/shapes/polyhedron.py
@@ -182,6 +182,16 @@ class Polyhedron(Shape3D):
             "faces": self.faces,
         }
 
+    def _rescale(self, scale):
+        """Multiply length scale.
+
+        Args:
+            scale (float):
+                Scale factor.
+        """
+        self._vertices *= scale
+        self._equations[:, 3] *= scale
+
     def merge_faces(self, atol=1e-8, rtol=1e-5):
         """Merge coplanar faces to a given tolerance.
 
@@ -352,9 +362,8 @@ class Polyhedron(Shape3D):
 
     @volume.setter
     def volume(self, value):
-        scale_factor = (value / self.volume) ** (1 / 3)
-        self._vertices *= scale_factor
-        self._equations[:, 3] *= scale_factor
+        scale = (value / self.volume) ** (1 / 3)
+        self._rescale(scale)
 
     def get_face_area(self, faces=None):
         """Get the total surface area of a set of faces.
@@ -397,6 +406,14 @@ class Polyhedron(Shape3D):
     def surface_area(self):
         """float: Get the surface area."""
         return np.sum(self.get_face_area())
+
+    @surface_area.setter
+    def surface_area(self, value):
+        if value > 0:
+            scale = np.sqrt(value / self.surface_area)
+            self._rescale(scale)
+        else:
+            raise ValueError("Surface area must be greater than zero.")
 
     def _surface_triangulation(self):
         """Generate a triangulation of the surface of the polyhedron.

--- a/coxeter/shapes/sphere.py
+++ b/coxeter/shapes/sphere.py
@@ -65,6 +65,15 @@ class Sphere(Shape3D):
         else:
             raise ValueError("Radius must be greater than zero.")
 
+    def _rescale(self, scale):
+        """Multiply length scale.
+
+        Args:
+            scale (float):
+                Scale factor.
+        """
+        self.radius *= scale
+
     @property
     def volume(self):
         """float: Get the volume of the sphere."""

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -54,8 +54,25 @@ def test_perimeter(a, b):
     assert ellipse.circumference == pytest.approx(approx_perimeter, rel=1e-3)
 
 
+@given(floats(0.1, 1000))
+def test_perimeter_setter(value):
+    """Test perimeter and circumference getter and setter."""
+    ellipse = Ellipse(1, 2)
+    perimeter_old = ellipse.perimeter
+    circumference_old = ellipse.circumference
+    ellipse.circumference = value
+    assert ellipse.circumference == approx(value)
+    assert ellipse.a == approx(1 * value / circumference_old)
+    assert ellipse.b == approx(2 * value / circumference_old)
+    ellipse = Ellipse(1, 2)
+    ellipse.perimeter = value
+    assert ellipse.perimeter == approx(value)
+    assert ellipse.a == approx(1 * value / perimeter_old)
+    assert ellipse.b == approx(2 * value / perimeter_old)
+
+
 @given(floats(0.1, 1000), floats(0.1, 1000))
-def test_area(a, b):
+def test_area_getter(a, b):
     ellipse = Ellipse(1, 1)
     ellipse.a = a
     ellipse.b = b

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -64,6 +64,18 @@ def test_surface_area(a, b, c):
     assert ellipsoid.surface_area == pytest.approx(approx_surface, rel=0.015)
 
 
+@given(floats(0.1, 1000))
+def test_set_surface_area(value):
+    """Test setting the surface area."""
+    ellipsoid = Ellipsoid(1, 2, 3)
+    area_old = ellipsoid.surface_area
+    ellipsoid.surface_area = value
+    assert ellipsoid.surface_area == approx(value)
+    assert ellipsoid.a == approx(1 * np.sqrt(value / area_old))
+    assert ellipsoid.b == approx(2 * np.sqrt(value / area_old))
+    assert ellipsoid.c == approx(3 * np.sqrt(value / area_old))
+
+
 @given(floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000))
 def test_volume(a, b, c):
     ellipsoid = Ellipsoid(1, 1, 1)

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -5,6 +5,7 @@ import rowan
 from hypothesis import assume, example, given, settings
 from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
+from pytest import approx
 from scipy.spatial import ConvexHull
 
 from conftest import EllipseSurfaceStrategy
@@ -375,4 +376,16 @@ def test_perimeter(num_sides):
     poly = RegularNGonFamily.get_shape(num_sides)
     assert np.isclose(
         num_sides * unit_area_regular_n_gon_side_length(num_sides), poly.perimeter
+    )
+
+
+@given(floats(0.1, 1000))
+def test_set_perimeter(value):
+    """Test the perimeter and circumference setter."""
+    square = RegularNGonFamily.get_shape(4)
+    square.perimeter = value
+    assert square.perimeter == approx(value)
+    assert square.vertices == approx(
+        RegularNGonFamily.get_shape(4).vertices
+        * (value / RegularNGonFamily.get_shape(4).perimeter)
     )

--- a/tests/test_polyhedron.py
+++ b/tests/test_polyhedron.py
@@ -6,6 +6,7 @@ import rowan
 from hypothesis import example, given, settings
 from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats, integers
+from pytest import approx
 from scipy.spatial import ConvexHull
 
 from conftest import (
@@ -46,6 +47,17 @@ def test_normal_detection(convex_cube):
 def test_surface_area(cube):
     """Test surface area calculation."""
     assert cube.surface_area == 6
+
+
+@pytest.mark.parametrize(
+    "cube", ["convex_cube", "oriented_cube", "unoriented_cube"], indirect=True
+)
+def test_set_surface_area(cube):
+    """Test surface area calculation."""
+    cube_old = cube
+    cube.surface_area = 4
+    assert cube.surface_area == approx(4)
+    assert cube.vertices == approx(cube_old.vertices * (4 / cube_old.surface_area))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from hypothesis import given
 from hypothesis.strategies import floats
+from pytest import approx
 
 from conftest import make_sphero_cube
 
@@ -22,6 +23,13 @@ def test_volume_polyhedron(convex_cube, cube_points):
     assert sphero_cube.volume == convex_cube.volume
 
 
+@given(value=floats(0.1, 1))
+def test_set_volume(value):
+    sphero_cube = make_sphero_cube(radius=0)
+    sphero_cube.volume = value
+    assert sphero_cube.volume == approx(value)
+
+
 @given(radius=floats(0.1, 1))
 def test_surface_area(radius):
     sphero_cube = make_sphero_cube(radius=radius)
@@ -29,6 +37,13 @@ def test_surface_area(radius):
     sa_sphere = 4 * np.pi * radius ** 2
     sa_cyl = 12 * (2 * np.pi * radius) / 4
     assert np.isclose(sphero_cube.surface_area, sa_cube + sa_sphere + sa_cyl)
+
+
+@given(value=floats(0.1, 1))
+def test_set_surface_area(value):
+    sphero_cube = make_sphero_cube(radius=0)
+    sphero_cube.surface_area = value
+    assert sphero_cube.surface_area == approx(value)
 
 
 def test_surface_area_polyhedron(convex_cube):


### PR DESCRIPTION
## Description
Use `_rescale` to change the length scale of all shapes. The method is implemented for each shape class, and allows for common logic for setters for properties like areas and volumes.

I also added several new property setters.

## Motivation and Context
Simplifies implementations of property setters.

@Tobias-Dwyer Would you like to add tests to this PR? Tests are missing for the new setters. You can model them after similar property tests for other classes. After you've tested them, we can mark them off on the Feature Matrix document.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
