### PR TITLE
Add to_plato_scene feature.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ __pycache__
 .hypothesis
 *.pyc
 doc/source/bibtex.json
+.ipynb_checkpoints

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -54,6 +54,7 @@ Added
 - Plotting polygons or polyhedra can automatically create matplotlib axes.
 - Perimeter calculation for polygons.
 - Area and perimeter setters for spheropolygons.
+- Shapes can be exported to plato scenes.
 
 Changed
 ~~~~~~~

--- a/Credits.rst
+++ b/Credits.rst
@@ -63,6 +63,7 @@ Bradley Dice
 * Added automatic axis creation for plotting.
 * Added spheropolygon area and perimeter setters.
 * Added ellipse area setter and ellipsoid volume setter.
+* Added plato support.
 
 Brandon Butler
 

--- a/coxeter/families/tabulated_shape_family.py
+++ b/coxeter/families/tabulated_shape_family.py
@@ -4,8 +4,8 @@
 """Define tabulated shape families.
 
 Tabulated shape families are defined by a dictionary of data that can be
-converted into a shape by some well-defined schema. One example is the
-`GSD shape schema <shapes>`, which defines how to translates dictionaries with
+converted into a shape by some well-defined schema. One example is the `GSD
+shape schema <gsd:shapes>`, which defines how to translates dictionaries with
 the appropriate formatting into a shape. These shape families may be
 constructed from a JSON file that can be read into a dictionary with the
 appropriate formatting.
@@ -90,7 +90,7 @@ class TabulatedGSDShapeFamily(TabulatedShapeFamily):
     """A tabulated shape family defined by a GSD shape schema.
 
     The values of the dictionary used to construct this class must adhere to
-    the :ref:`GSD shape spec <shapes>`. Each mapping may contain additional
+    the :ref:`GSD shape spec <gsd:shapes>`. Each mapping may contain additional
     data, which is ignored when the class is called to actually produce
     :class:`~coxeter.shapes.Shape` objects.
 

--- a/coxeter/shape_getters.py
+++ b/coxeter/shape_getters.py
@@ -27,9 +27,9 @@ def from_gsd_type_shapes(params, dimensions=3):  # noqa: C901
     See :ref:`here <gsd:shapes>` for the specification of the schema. Note that
     the schema does not differentiate between 2D and 3D shapes for spheres (vs.
     circles) and ellipsoids (vs. ellipses) because in context the
-    dimensionality of the shape can be inferred from simulation boxes. To
-    address this ambiguity, this function accepts a dimensions parameter that
-    can be used to disambiguate explicitly between these two cases.
+    dimensionality of those shapes can be inferred from simulation boxes. To
+    address this ambiguity, this function accepts a ``dimensions`` parameter
+    that can be used to disambiguate explicitly between these two cases.
 
     Args:
         params (dict):

--- a/coxeter/shape_getters.py
+++ b/coxeter/shape_getters.py
@@ -24,12 +24,12 @@ from .shapes import (
 def from_gsd_type_shapes(params, dimensions=3):  # noqa: C901
     """Create a :class:`~.Shape` from a dict conforming to the GSD schema.
 
-    See :ref:`here <gsd:shapes>` for the specification of the schema. Note
-    that the schema does not differentiate between 2D and 3D shapes for
-    spheres (vs. circles) and ellipsoids (vs. ellipses) because in context
-    those can be inferred from simulation boxes. To address this ambiguity,
-    this function accepts a dimensions parameter that can be used to
-    disambiguate explicitly between these two cases.
+    See :ref:`here <gsd:shapes>` for the specification of the schema. Note that
+    the schema does not differentiate between 2D and 3D shapes for spheres (vs.
+    circles) and ellipsoids (vs. ellipses) because in context the
+    dimensionality of the shape can be inferred from simulation boxes. To
+    address this ambiguity, this function accepts a dimensions parameter that
+    can be used to disambiguate explicitly between these two cases.
 
     Args:
         params (dict):

--- a/coxeter/shape_getters.py
+++ b/coxeter/shape_getters.py
@@ -24,12 +24,12 @@ from .shapes import (
 def from_gsd_type_shapes(params, dimensions=3):  # noqa: C901
     """Create a :class:`~.Shape` from a dict conforming to the GSD schema.
 
-    See :ref:`here <shapes>` for the specification of the schema. Note that the
-    schema does not differentiate between 2D and 3D shapes for spheres (vs
-    circles) and ellipsoids (vs ellipses) because in context those can be
-    inferred from simulation boxes.  To address this ambiguity, this function
-    accepts a dimensions parameter that can be used to disambiguate explicitly
-    between these two cases.
+    See :ref:`here <gsd:shapes>` for the specification of the schema. Note
+    that the schema does not differentiate between 2D and 3D shapes for
+    spheres (vs. circles) and ellipsoids (vs. ellipses) because in context
+    those can be inferred from simulation boxes. To address this ambiguity,
+    this function accepts a dimensions parameter that can be used to
+    disambiguate explicitly between these two cases.
 
     Args:
         params (dict):

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -133,6 +133,41 @@ class Shape(ABC):
     def __str__(self):
         return repr(self)
 
+    def _plato_primitive(self, backend, **kwargs):
+        raise NotImplementedError("This shape does not have a plato primitive.")
+
+    def to_plato_scene(self, backend=None, scene=None):
+        """Create a plato scene displaying this shape.
+
+        Args:
+            backend (str):
+                Name of backend to use from plato. The backend must support
+                the primitive corresponding to this shape. Defaults to None,
+                in which case the ``scene`` argument must be provided.
+            scene (:class:`plato.draw.Scene`):
+                Scene object to render into. If not provided or None, a new
+                scene is created.
+        """
+        if backend is None and scene is None:
+            raise ValueError("Either backend or scene must be specified.")
+
+        try:
+            import importlib
+
+            backend = importlib.import_module("plato.draw.{}".format(backend))
+        except ImportError:
+            raise ImportError(
+                "Backend plato.draw.{} could not be imported.".format(backend)
+            )
+
+        prim = self._plato_primitive(backend)
+
+        if scene is None:
+            scene = backend.Scene([prim])
+        else:
+            scene.add_primitive(prim)
+        return scene
+
 
 class Shape2D(Shape):
     """An abstract representation of a shape in 2 dimensions."""

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -139,18 +139,22 @@ class Shape(ABC):
     def to_plato_scene(self, backend=None, scene=None, **scene_kwargs):
         r"""Add this shape to a new or existing :class:`plato.draw.Scene`.
 
-        The plato visualization package provides support for several backends.
-        Each backend supports different primitives (geometry objects) and may
-        not support the primitive corresponding to a specific shape class in
+        The plato visualization package provides support for several backends,
+        including matplotlib, fresnel, povray, pythreejs, and vispy. Each
+        backend supports different primitives (geometry objects) and may not
+        support the primitive corresponding to a specific shape class in
         coxeter. Please refer to the `plato documentation
         <https://plato-draw.readthedocs.io/>`__ for more information about
         supported primitives for each backend.
 
         Args:
             backend (str):
-                Name of backend to use from plato. The backend must support
-                the primitive corresponding to this shape. Defaults to None,
-                in which case the ``scene`` argument must be provided.
+                Name of backend to use from plato. The backend must support the
+                primitive corresponding to this shape. Defaults to None, in
+                which case the ``scene`` argument must be provided.  Supported
+                values include ``"matplotlib"``, ``"fresnel"``, ``"povray"``,
+                ``"pythreejs"``, ``"vispy"``, and ``"zdog"``. See plato
+                documentation for more information.
             scene (:class:`plato.draw.Scene`):
                 Scene object to render into. If not provided or None, a new
                 scene is created.

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -147,7 +147,7 @@ class Shape(ABC):
             scene (:class:`plato.draw.Scene`):
                 Scene object to render into. If not provided or None, a new
                 scene is created.
-            **scene_kwargs:
+            \*\*scene_kwargs:
                 Keyword arguments forwarded to the :class:`plato.draw.Scene`.
                 Only used if ``scene`` is not provided or None.
 

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -136,25 +136,26 @@ class Shape(ABC):
     def _plato_primitive(self, backend, **kwargs):
         raise NotImplementedError("This shape does not have a plato primitive.")
 
-    def to_plato_scene(self, backend=None, scene=None, **scene_kwargs):
+    def to_plato_scene(self, backend="matplotlib", scene=None, **scene_kwargs):
         r"""Add this shape to a new or existing :class:`plato.draw.Scene`.
 
         The plato visualization package provides support for several backends,
-        including matplotlib, fresnel, povray, pythreejs, and vispy. Each
-        backend supports different primitives (geometry objects) and may not
-        support the primitive corresponding to a specific shape class in
-        coxeter. Please refer to the `plato documentation
+        including matplotlib, fresnel, povray, pythreejs, and vispy. The backend
+        package must be separately installed by the user. Each backend supports
+        different primitives (geometry objects) and may not support the
+        primitive corresponding to a specific shape class in coxeter. Please
+        refer to the `plato documentation
         <https://plato-draw.readthedocs.io/>`__ for more information about
         supported primitives for each backend.
 
         Args:
             backend (str):
                 Name of backend to use from plato. The backend must support the
-                primitive corresponding to this shape. Defaults to None, in
-                which case the ``scene`` argument must be provided.  Supported
-                values include ``"matplotlib"``, ``"fresnel"``, ``"povray"``,
-                ``"pythreejs"``, ``"vispy"``, and ``"zdog"``. See plato
-                documentation for more information.
+                primitive corresponding to this shape. Defaults to
+                ``"matplotlib"``.  Supported values include ``"matplotlib"``,
+                ``"fresnel"``, ``"povray"``, ``"pythreejs"``, ``"vispy"``, and
+                ``"zdog"``. See plato documentation for more information about
+                each backend.
             scene (:class:`plato.draw.Scene`):
                 Scene object to render into. If not provided or None, a new
                 scene is created.
@@ -173,9 +174,6 @@ class Shape(ABC):
                 If the selected plato backend does not support the primitive for
                 this coxeter shape class.
         """
-        if backend is None and scene is None:
-            raise ValueError("Either backend or scene must be specified.")
-
         try:
             import importlib
 

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -139,6 +139,13 @@ class Shape(ABC):
     def to_plato_scene(self, backend=None, scene=None, **scene_kwargs):
         r"""Add this shape to a new or existing :class:`plato.draw.Scene`.
 
+        The plato visualization package provides support for several backends.
+        Each backend supports different primitives (geometry objects) and may
+        not support the primitive corresponding to a specific shape class in
+        coxeter. Please refer to the `plato documentation
+        <https://plato-draw.readthedocs.io/>`__ for more information about
+        supported primitives for each backend.
+
         Args:
             backend (str):
                 Name of backend to use from plato. The backend must support
@@ -154,6 +161,13 @@ class Shape(ABC):
         Returns:
             :class:`plato.draw.Scene`:
                 A scene containing this shape.
+
+        Raises:
+            `NotImplementedError`:
+                If no plato primitive corresponds to this coxeter shape class.
+            `AttributeError`:
+                If the selected plato backend does not support the primitive for
+                this coxeter shape class.
         """
         if backend is None and scene is None:
             raise ValueError("Either backend or scene must be specified.")

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -175,22 +175,22 @@ class Shape(ABC):
                 If the selected plato backend does not support the primitive for
                 this coxeter shape class.
         """
-        try:
-            import importlib
-
-            backend = importlib.import_module("plato.draw.{}".format(backend))
-        except ImportError:
-            raise ImportError(
-                "Backend plato.draw.{} could not be imported.".format(backend)
-            )
-
-        prim = self._plato_primitive(backend)
 
         if scene is None:
+            try:
+                import importlib
+
+                backend = importlib.import_module("plato.draw.{}".format(backend))
+            except ImportError:
+                raise ImportError(
+                    "Backend plato.draw.{} could not be imported.".format(backend)
+                )
             if scene_kwargs is None:
                 scene_kwargs = {}
+            prim = self._plato_primitive(backend)
             scene = backend.Scene([prim], **scene_kwargs)
         else:
+            prim = self._plato_primitive(backend)
             scene.add_primitive(prim)
         return scene
 

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -175,7 +175,6 @@ class Shape(ABC):
                 If the selected plato backend does not support the primitive for
                 this coxeter shape class.
         """
-
         if scene is None:
             try:
                 import importlib

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -43,7 +43,7 @@ class Shape(ABC):
 
     @property
     def gsd_shape_spec(self):
-        """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
+        """dict: Get a :ref:`complete GSD specification <gsd:shapes>`."""  # noqa: D401
         raise NotImplementedError
 
     def is_inside(self, points):
@@ -137,7 +137,7 @@ class Shape(ABC):
         raise NotImplementedError("This shape does not have a plato primitive.")
 
     def to_plato_scene(self, backend=None, scene=None):
-        """Create a plato scene displaying this shape.
+        """Add this shape to a new or existing :class:`plato.draw.Scene`.
 
         Args:
             backend (str):
@@ -147,6 +147,10 @@ class Shape(ABC):
             scene (:class:`plato.draw.Scene`):
                 Scene object to render into. If not provided or None, a new
                 scene is created.
+
+        Returns:
+            :class:`plato.draw.Scene`:
+                A scene containing this shape.
         """
         if backend is None and scene is None:
             raise ValueError("Either backend or scene must be specified.")

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -169,9 +169,9 @@ class Shape(ABC):
                 A scene containing this shape.
 
         Raises:
-            `NotImplementedError`:
+            NotImplementedError:
                 If no plato primitive corresponds to this coxeter shape class.
-            `AttributeError`:
+            AttributeError:
                 If the selected plato backend does not support the primitive for
                 this coxeter shape class.
         """

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -136,8 +136,8 @@ class Shape(ABC):
     def _plato_primitive(self, backend, **kwargs):
         raise NotImplementedError("This shape does not have a plato primitive.")
 
-    def to_plato_scene(self, backend=None, scene=None):
-        """Add this shape to a new or existing :class:`plato.draw.Scene`.
+    def to_plato_scene(self, backend=None, scene=None, **scene_kwargs):
+        r"""Add this shape to a new or existing :class:`plato.draw.Scene`.
 
         Args:
             backend (str):
@@ -147,6 +147,9 @@ class Shape(ABC):
             scene (:class:`plato.draw.Scene`):
                 Scene object to render into. If not provided or None, a new
                 scene is created.
+            **scene_kwargs:
+                Keyword arguments forwarded to the :class:`plato.draw.Scene`.
+                Only used if ``scene`` is not provided or None.
 
         Returns:
             :class:`plato.draw.Scene`:
@@ -167,7 +170,7 @@ class Shape(ABC):
         prim = self._plato_primitive(backend)
 
         if scene is None:
-            scene = backend.Scene([prim])
+            scene = backend.Scene([prim], **scene_kwargs)
         else:
             scene.add_primitive(prim)
         return scene

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -136,7 +136,7 @@ class Shape(ABC):
     def _plato_primitive(self, backend, **kwargs):
         raise NotImplementedError("This shape does not have a plato primitive.")
 
-    def to_plato_scene(self, backend="matplotlib", scene=None, **scene_kwargs):
+    def to_plato_scene(self, backend="matplotlib", scene=None, scene_kwargs=None):
         r"""Add this shape to a new or existing :class:`plato.draw.Scene`.
 
         The plato visualization package provides support for several backends,
@@ -151,17 +151,18 @@ class Shape(ABC):
         Args:
             backend (str):
                 Name of backend to use from plato. The backend must support the
-                primitive corresponding to this shape. Defaults to
-                ``"matplotlib"``.  Supported values include ``"matplotlib"``,
+                primitive corresponding to this shape (Default value:
+                ``"matplotlib"``). Supported values include ``"matplotlib"``,
                 ``"fresnel"``, ``"povray"``, ``"pythreejs"``, ``"vispy"``, and
                 ``"zdog"``. See plato documentation for more information about
                 each backend.
             scene (:class:`plato.draw.Scene`):
                 Scene object to render into. If not provided or None, a new
-                scene is created.
-            \*\*scene_kwargs:
-                Keyword arguments forwarded to the :class:`plato.draw.Scene`.
-                Only used if ``scene`` is not provided or None.
+                scene is created (Default value: None).
+            scene_kwargs (dict):
+                Keyword arguments forwarded to the :class:`plato.draw.Scene`
+                (Default value: None). Only used if ``scene`` is not provided
+                or None.
 
         Returns:
             :class:`plato.draw.Scene`:
@@ -186,6 +187,8 @@ class Shape(ABC):
         prim = self._plato_primitive(backend)
 
         if scene is None:
+            if scene_kwargs is None:
+                scene_kwargs = {}
             scene = backend.Scene([prim], **scene_kwargs)
         else:
             scene.add_primitive(prim)

--- a/coxeter/shapes/circle.py
+++ b/coxeter/shapes/circle.py
@@ -221,3 +221,10 @@ class Circle(Shape2D):
             f"coxeter.shapes.Circle(radius={self.radius}, "
             f"center={self.centroid.tolist()})"
         )
+
+    def _plato_primitive(self, backend):
+        return backend.Disks(
+            positions=np.array([self.center[:2]]),
+            colors=np.array([[0.5, 0.5, 0.5, 1]]),
+            radii=[self.radius],
+        )

--- a/coxeter/shapes/circle.py
+++ b/coxeter/shapes/circle.py
@@ -47,7 +47,7 @@ class Circle(Shape2D):
 
     @property
     def gsd_shape_spec(self):
-        """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
+        """dict: Get a :ref:`complete GSD specification <gsd:shapes>`."""  # noqa: D401
         return {"type": "Sphere", "diameter": 2 * self.radius}
 
     @property

--- a/coxeter/shapes/convex_polyhedron.py
+++ b/coxeter/shapes/convex_polyhedron.py
@@ -107,7 +107,7 @@ class ConvexPolyhedron(Polyhedron):
 
     @property
     def gsd_shape_spec(self):
-        """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
+        """dict: Get a :ref:`complete GSD specification <gsd:shapes>`."""  # noqa: D401
         return {"type": "ConvexPolyhedron", "vertices": self.vertices.tolist()}
 
     @property

--- a/coxeter/shapes/convex_polyhedron.py
+++ b/coxeter/shapes/convex_polyhedron.py
@@ -196,5 +196,5 @@ class ConvexPolyhedron(Polyhedron):
             positions=np.array([self.center]),
             orientations=np.array([[1.0, 0.0, 0.0, 0.0]]),
             colors=np.array([[0.5, 0.5, 0.5, 1]]),
-            vertices=verts[:, :2],
+            vertices=self.vertices,
         )

--- a/coxeter/shapes/convex_polyhedron.py
+++ b/coxeter/shapes/convex_polyhedron.py
@@ -190,3 +190,11 @@ class ConvexPolyhedron(Polyhedron):
             )
         min_distance = -np.max(distances)
         return Sphere(min_distance, center)
+
+    def _plato_primitive(self, backend):
+        return backend.ConvexPolyhedra(
+            positions=np.array([self.center]),
+            orientations=np.array([[1.0, 0.0, 0.0, 0.0]]),
+            colors=np.array([[0.5, 0.5, 0.5, 1]]),
+            vertices=verts[:, :2],
+        )

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -63,7 +63,7 @@ class ConvexSpheropolygon(Shape2D):
 
     @property
     def gsd_shape_spec(self):
-        """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
+        """dict: Get a :ref:`complete GSD specification <gsd:shapes>`."""  # noqa: D401
         return {
             "type": "Polygon",
             "vertices": self.polygon.vertices.tolist(),

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -257,7 +257,9 @@ class ConvexSpheropolygon(Shape2D):
         )
 
     def _plato_primitive(self, backend):
-        verts = _align_points_by_normal(self.normal, self.vertices - self.center)
+        verts = _align_points_by_normal(
+            self.normal, self.vertices - self.polygon.center
+        )[0]
         return backend.Spheropolygons(
             positions=np.array([[0.0, 0.0]]),
             orientations=np.array([[1.0, 0.0, 0.0, 0.0]]),

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from .base_classes import Shape2D
 from .convex_polygon import ConvexPolygon, _is_convex
+from .polygon import _align_points_by_normal
 
 
 class ConvexSpheropolygon(Shape2D):
@@ -68,6 +69,11 @@ class ConvexSpheropolygon(Shape2D):
             "vertices": self.polygon.vertices.tolist(),
             "rounding_radius": self.radius,
         }
+
+    @property
+    def normal(self):
+        """:math:`(3, )` :class:`numpy.ndarray` of float: Get the normal vector."""
+        return self._polygon.normal
 
     @property
     def vertices(self):
@@ -248,4 +254,14 @@ class ConvexSpheropolygon(Shape2D):
         return (
             f"coxeter.shapes.ConvexSpheropolygon(vertices={self.vertices.tolist()}, "
             f"radius={self.radius}, normal={self.polygon.normal.tolist()})"
+        )
+
+    def _plato_primitive(self, backend):
+        verts = _align_points_by_normal(self.normal, self.vertices - self.center)
+        return backend.Spheropolygons(
+            positions=np.array([[0.0, 0.0]]),
+            orientations=np.array([[1.0, 0.0, 0.0, 0.0]]),
+            colors=np.array([[0.5, 0.5, 0.5, 1]]),
+            vertices=verts[:, :2],
+            radius=self.radius,
         )

--- a/coxeter/shapes/convex_spheropolyhedron.py
+++ b/coxeter/shapes/convex_spheropolyhedron.py
@@ -294,3 +294,12 @@ class ConvexSpheropolyhedron(Shape3D):
             f"coxeter.shapes.ConvexSpheropolyhedron(vertices={self.vertices.tolist()}, "
             f"radius={self.radius})"
         )
+
+    def _plato_primitive(self, backend):
+        return backend.ConvexSpheropolyhedra(
+            positions=np.array([self.center]),
+            orientations=np.array([[1.0, 0.0, 0.0, 0.0]]),
+            colors=np.array([[0.5, 0.5, 0.5, 1]]),
+            vertices=self.vertices,
+            radius=self.radius,
+        )

--- a/coxeter/shapes/convex_spheropolyhedron.py
+++ b/coxeter/shapes/convex_spheropolyhedron.py
@@ -70,7 +70,7 @@ class ConvexSpheropolyhedron(Shape3D):
 
     @property
     def gsd_shape_spec(self):
-        """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
+        """dict: Get a :ref:`complete GSD specification <gsd:shapes>`."""  # noqa: D401
         return {
             "type": "ConvexPolyhedron",
             "vertices": self.polyhedron.vertices.tolist(),

--- a/coxeter/shapes/convex_spheropolyhedron.py
+++ b/coxeter/shapes/convex_spheropolyhedron.py
@@ -297,7 +297,7 @@ class ConvexSpheropolyhedron(Shape3D):
 
     def _plato_primitive(self, backend):
         return backend.ConvexSpheropolyhedra(
-            positions=np.array([self.center]),
+            positions=np.array([self.polyhedron.center]),
             orientations=np.array([[1.0, 0.0, 0.0, 0.0]]),
             colors=np.array([[0.5, 0.5, 0.5, 1]]),
             vertices=self.vertices,

--- a/coxeter/shapes/ellipse.py
+++ b/coxeter/shapes/ellipse.py
@@ -55,7 +55,7 @@ class Ellipse(Shape2D):
 
     @property
     def gsd_shape_spec(self):
-        """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
+        """dict: Get a :ref:`complete GSD specification <gsd:shapes>`."""  # noqa: D401
         return {"type": "Ellipsoid", "a": self.a, "b": self.b}
 
     @property

--- a/coxeter/shapes/ellipsoid.py
+++ b/coxeter/shapes/ellipsoid.py
@@ -61,7 +61,7 @@ class Ellipsoid(Shape3D):
 
     @property
     def gsd_shape_spec(self):
-        """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
+        """dict: Get a :ref:`complete GSD specification <gsd:shapes>`."""  # noqa: D401
         return {"type": "Ellipsoid", "a": self.a, "b": self.b, "c": self.c}
 
     @property

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -710,3 +710,12 @@ class Polygon(Shape2D):
             f"coxeter.shapes.Polygon(vertices={self.vertices.tolist()}, "
             f"normal={self.normal.tolist()})"
         )
+
+    def _plato_primitive(self, backend):
+        verts = _align_points_by_normal(self.normal, self.vertices - self.center)
+        return backend.Polygons(
+            positions=np.array([[0.0, 0.0]]),
+            orientations=np.array([[1.0, 0.0, 0.0, 0.0]]),
+            colors=np.array([[0.5, 0.5, 0.5, 1]]),
+            vertices=verts[:, :2],
+        )

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -712,7 +712,7 @@ class Polygon(Shape2D):
         )
 
     def _plato_primitive(self, backend):
-        verts = _align_points_by_normal(self.normal, self.vertices - self.center)
+        verts = _align_points_by_normal(self.normal, self.vertices - self.center)[0]
         return backend.Polygons(
             positions=np.array([[0.0, 0.0]]),
             orientations=np.array([[1.0, 0.0, 0.0, 0.0]]),

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -183,7 +183,7 @@ class Polygon(Shape2D):
 
     @property
     def gsd_shape_spec(self):
-        """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
+        """dict: Get a :ref:`complete GSD specification <gsd:shapes>`."""  # noqa: D401
         return {"type": "Polygon", "vertices": self.vertices.tolist()}
 
     @property

--- a/coxeter/shapes/polyhedron.py
+++ b/coxeter/shapes/polyhedron.py
@@ -180,7 +180,7 @@ class Polyhedron(Shape3D):
 
     @property
     def gsd_shape_spec(self):
-        """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
+        """dict: Get a :ref:`complete GSD specification <gsd:shapes>`."""  # noqa: D401
         return {
             "type": "Mesh",
             "vertices": self.vertices.tolist(),

--- a/coxeter/shapes/polyhedron.py
+++ b/coxeter/shapes/polyhedron.py
@@ -858,3 +858,13 @@ class Polyhedron(Shape3D):
             f"coxeter.shapes.Polyhedron(vertices={self.vertices.tolist()}, "
             f"faces={np.asarray(self.faces).tolist()})"
         )
+
+    def _plato_primitive(self, backend):
+        return backend.Mesh(
+            positions=np.array([self.center]),
+            orientations=np.array([[1.0, 0.0, 0.0, 0.0]]),
+            colors=np.array([[0.5, 0.5, 0.5, 1]] * len(self.vertices)),
+            vertices=self.vertices,
+            indices=self.faces,
+            shape_colors=np.array([[0.5, 0.5, 0.5, 1]]),
+        )

--- a/coxeter/shapes/sphere.py
+++ b/coxeter/shapes/sphere.py
@@ -194,3 +194,10 @@ class Sphere(Shape3D):
             f"coxeter.shapes.Sphere(radius={self.radius}, "
             f"center={self.centroid.tolist()})"
         )
+
+    def _plato_primitive(self, backend):
+        return backend.Spheres(
+            positions=np.array([self.center]),
+            colors=np.array([[0.5, 0.5, 0.5, 1]]),
+            radii=[self.radius],
+        )

--- a/coxeter/shapes/sphere.py
+++ b/coxeter/shapes/sphere.py
@@ -43,7 +43,7 @@ class Sphere(Shape3D):
 
     @property
     def gsd_shape_spec(self):
-        """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
+        """dict: Get a :ref:`complete GSD specification <gsd:shapes>`."""  # noqa: D401
         return {"type": "Sphere", "diameter": 2 * self.radius}
 
     @property

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -58,6 +58,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "matplotlib": ("https://matplotlib.org", None),
     "gsd": ("https://gsd.readthedocs.io/en/stable/", None),
+    "plato": ("https://plato-draw.readthedocs.io/en/latest/", None),
 }
 
 autodoc_default_options = {

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,10 @@ version = "0.5.0"
 ################################################
 
 test_deps = [
-    "pytest",
     "hypothesis[numpy]",
+    "matplotlib",
+    "plato-draw",
+    "pytest",
 ]
 
 bounding_deps = [

--- a/tests/test_plato.py
+++ b/tests/test_plato.py
@@ -22,7 +22,7 @@ except ImportError:
 def test_draw_circle():
     circle = coxeter.shapes.Circle(1)
     scene = circle.to_plato_scene("matplotlib", zoom=10)
-    with tempfile.NamedTemporaryFile() as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
         scene.save(tmp.name)
 
 
@@ -33,7 +33,7 @@ def test_draw_circle():
 def test_draw_polygon():
     polygon = coxeter.shapes.Polygon([[0, 0], [1, 0], [0, 1]])
     scene = polygon.to_plato_scene("matplotlib", zoom=10)
-    with tempfile.NamedTemporaryFile() as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
         scene.save(tmp.name)
 
 
@@ -44,7 +44,7 @@ def test_draw_polygon():
 def test_draw_convex_polygon():
     polygon = coxeter.shapes.ConvexPolygon([[0, 0], [1, 0], [0, 1]])
     scene = polygon.to_plato_scene("matplotlib", zoom=10)
-    with tempfile.NamedTemporaryFile() as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
         scene.save(tmp.name)
 
 
@@ -55,5 +55,38 @@ def test_draw_convex_polygon():
 def test_draw_spheropolygon():
     spheropolygon = coxeter.shapes.ConvexSpheropolygon([[0, 0], [1, 0], [0, 1]], 0.3)
     scene = spheropolygon.to_plato_scene("matplotlib", zoom=10)
-    with tempfile.NamedTemporaryFile() as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
+        scene.save(tmp.name)
+
+
+@pytest.mark.skipif(
+    not MATPLOTLIB_PLATO_AVAILABLE,
+    reason="plato and matplotlib are required for this test.",
+)
+def test_draw_sphere():
+    sphere = coxeter.shapes.Sphere(1)
+    scene = sphere.to_plato_scene("matplotlib", zoom=10)
+    with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
+        scene.save(tmp.name)
+
+
+@pytest.mark.skipif(
+    not MATPLOTLIB_PLATO_AVAILABLE,
+    reason="plato and matplotlib are required for this test.",
+)
+def test_draw_convex_polyhedron():
+    cube = coxeter.shapes.ConvexPolyhedron(
+        [
+            [0, 0, 0],
+            [0, 1, 0],
+            [1, 1, 0],
+            [1, 0, 0],
+            [0, 0, 1],
+            [0, 1, 1],
+            [1, 1, 1],
+            [1, 0, 1],
+        ]
+    )
+    scene = cube.to_plato_scene("matplotlib", zoom=10)
+    with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
         scene.save(tmp.name)

--- a/tests/test_plato.py
+++ b/tests/test_plato.py
@@ -21,7 +21,7 @@ except ImportError:
 )
 def test_draw_circle():
     circle = coxeter.shapes.Circle(1)
-    scene = circle.to_plato_scene("matplotlib", zoom=10)
+    scene = circle.to_plato_scene("matplotlib", scene_kwargs=dict(zoom=10))
     with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
         scene.save(tmp.name)
 
@@ -32,7 +32,7 @@ def test_draw_circle():
 )
 def test_draw_polygon():
     polygon = coxeter.shapes.Polygon([[0, 0], [1, 0], [0, 1]])
-    scene = polygon.to_plato_scene("matplotlib", zoom=10)
+    scene = polygon.to_plato_scene("matplotlib", scene_kwargs=dict(zoom=10))
     with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
         scene.save(tmp.name)
 
@@ -43,7 +43,7 @@ def test_draw_polygon():
 )
 def test_draw_convex_polygon():
     polygon = coxeter.shapes.ConvexPolygon([[0, 0], [1, 0], [0, 1]])
-    scene = polygon.to_plato_scene("matplotlib", zoom=10)
+    scene = polygon.to_plato_scene("matplotlib", scene_kwargs=dict(zoom=10))
     with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
         scene.save(tmp.name)
 
@@ -54,7 +54,7 @@ def test_draw_convex_polygon():
 )
 def test_draw_spheropolygon():
     spheropolygon = coxeter.shapes.ConvexSpheropolygon([[0, 0], [1, 0], [0, 1]], 0.3)
-    scene = spheropolygon.to_plato_scene("matplotlib", zoom=10)
+    scene = spheropolygon.to_plato_scene("matplotlib", scene_kwargs=dict(zoom=10))
     with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
         scene.save(tmp.name)
 
@@ -65,7 +65,7 @@ def test_draw_spheropolygon():
 )
 def test_draw_sphere():
     sphere = coxeter.shapes.Sphere(1)
-    scene = sphere.to_plato_scene("matplotlib", zoom=10)
+    scene = sphere.to_plato_scene("matplotlib", scene_kwargs=dict(zoom=10))
     with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
         scene.save(tmp.name)
 
@@ -87,6 +87,6 @@ def test_draw_convex_polyhedron():
             [1, 0, 1],
         ]
     )
-    scene = cube.to_plato_scene("matplotlib", zoom=10)
+    scene = cube.to_plato_scene("matplotlib", scene_kwargs=dict(zoom=10))
     with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
         scene.save(tmp.name)

--- a/tests/test_plato.py
+++ b/tests/test_plato.py
@@ -1,5 +1,7 @@
 import tempfile
 
+import pytest
+
 import coxeter
 
 try:
@@ -13,6 +15,10 @@ except ImportError:
     MATPLOTLIB_PLATO_AVAILABLE = False
 
 
+@pytest.mark.skipif(
+    not MATPLOTLIB_PLATO_AVAILABLE,
+    reason="plato and matplotlib are required for this test.",
+)
 def test_draw_circle():
     circle = coxeter.shapes.Circle(1)
     scene = circle.to_plato_scene("matplotlib", zoom=10)
@@ -20,6 +26,10 @@ def test_draw_circle():
         scene.save(tmp.name)
 
 
+@pytest.mark.skipif(
+    not MATPLOTLIB_PLATO_AVAILABLE,
+    reason="plato and matplotlib are required for this test.",
+)
 def test_draw_polygon():
     polygon = coxeter.shapes.Polygon([[0, 0], [1, 0], [0, 1]])
     scene = polygon.to_plato_scene("matplotlib", zoom=10)
@@ -27,6 +37,10 @@ def test_draw_polygon():
         scene.save(tmp.name)
 
 
+@pytest.mark.skipif(
+    not MATPLOTLIB_PLATO_AVAILABLE,
+    reason="plato and matplotlib are required for this test.",
+)
 def test_draw_convex_polygon():
     polygon = coxeter.shapes.ConvexPolygon([[0, 0], [1, 0], [0, 1]])
     scene = polygon.to_plato_scene("matplotlib", zoom=10)
@@ -34,6 +48,10 @@ def test_draw_convex_polygon():
         scene.save(tmp.name)
 
 
+@pytest.mark.skipif(
+    not MATPLOTLIB_PLATO_AVAILABLE,
+    reason="plato and matplotlib are required for this test.",
+)
 def test_draw_spheropolygon():
     spheropolygon = coxeter.shapes.ConvexSpheropolygon([[0, 0], [1, 0], [0, 1]], 0.3)
     scene = spheropolygon.to_plato_scene("matplotlib", zoom=10)

--- a/tests/test_plato.py
+++ b/tests/test_plato.py
@@ -1,0 +1,41 @@
+import tempfile
+
+import coxeter
+
+try:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import plato.draw.matplotlib  # noqa: F401
+
+    MATPLOTLIB_PLATO_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_PLATO_AVAILABLE = False
+
+
+def test_draw_circle():
+    circle = coxeter.shapes.Circle(1)
+    scene = circle.to_plato_scene("matplotlib", zoom=10)
+    with tempfile.NamedTemporaryFile() as tmp:
+        scene.save(tmp.name)
+
+
+def test_draw_polygon():
+    polygon = coxeter.shapes.Polygon([[0, 0], [1, 0], [0, 1]])
+    scene = polygon.to_plato_scene("matplotlib", zoom=10)
+    with tempfile.NamedTemporaryFile() as tmp:
+        scene.save(tmp.name)
+
+
+def test_draw_convex_polygon():
+    polygon = coxeter.shapes.ConvexPolygon([[0, 0], [1, 0], [0, 1]])
+    scene = polygon.to_plato_scene("matplotlib", zoom=10)
+    with tempfile.NamedTemporaryFile() as tmp:
+        scene.save(tmp.name)
+
+
+def test_draw_spheropolygon():
+    spheropolygon = coxeter.shapes.ConvexSpheropolygon([[0, 0], [1, 0], [0, 1]], 0.3)
+    scene = spheropolygon.to_plato_scene("matplotlib", zoom=10)
+    with tempfile.NamedTemporaryFile() as tmp:
+        scene.save(tmp.name)


### PR DESCRIPTION

[plato_scenes.pdf](https://github.com/glotzerlab/coxeter/files/5927311/plato_scenes.pdf)

## Description
Allows shapes to be displayed as [plato](https://plato-draw.readthedocs.io/en/latest/) scenes.

Most shapes are shown at `self.center`. Polygon-like shapes must be shown in a 2D scene, and thus must be rotated so that their normal is `[0, 0, 1]` and their center is the origin. Orientations are assumed to be `[1, 0, 0, 0]`. Colors are set to 50% gray.

## Motivation and Context
Possible replacement for the `plot` method.

See the attached file for rendered examples!

@glotzerlab/coxeter-maintainers how do we want to test this? Add optional tests that function if plato is installed? If so, there is another issue that backends might still not be installed, so this is just hard to test on CI. In garnett, we have [a pretty hacky workaround](https://github.com/glotzerlab/garnett/blob/f9cb7bad391299e28feb4010eb77447fdc4512cb/tests/test_plato_scenes.py#L79-L92).

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
