### PR TITLE
Use public properties everywhere.

### DIFF
--- a/coxeter/shapes/circle.py
+++ b/coxeter/shapes/circle.py
@@ -40,12 +40,12 @@ class Circle(Shape2D):
 
     def __init__(self, radius, center=(0, 0, 0)):
         self.radius = radius
-        self._center = np.asarray(center)
+        self.center = center
 
     @property
     def gsd_shape_spec(self):
         """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
-        return {"type": "Sphere", "diameter": 2 * self._radius}
+        return {"type": "Sphere", "diameter": 2 * self.radius}
 
     @property
     def center(self):

--- a/coxeter/shapes/convex_polygon.py
+++ b/coxeter/shapes/convex_polygon.py
@@ -97,7 +97,7 @@ class ConvexPolygon(Polygon):
 
     def __init__(self, vertices, normal=None, planar_tolerance=1e-5):
         super(ConvexPolygon, self).__init__(vertices, normal, planar_tolerance, False)
-        if _is_convex(self._vertices, self._normal):
+        if _is_convex(self.vertices, self.normal):
             # If points form a convex set, then we can order the vertices. We
             # cannot directly use the output of scipy's convex hull because our
             # polygon may be embedded in 3D, so we sort ourselves.

--- a/coxeter/shapes/convex_polyhedron.py
+++ b/coxeter/shapes/convex_polyhedron.py
@@ -103,7 +103,7 @@ class ConvexPolyhedron(Polyhedron):
     @property
     def gsd_shape_spec(self):
         """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
-        return {"type": "ConvexPolyhedron", "vertices": self._vertices.tolist()}
+        return {"type": "ConvexPolyhedron", "vertices": self.vertices.tolist()}
 
     @property
     def tau(self):
@@ -171,4 +171,4 @@ class ConvexPolyhedron(Polyhedron):
                 "The centroid is not contained in the shape. The "
                 "circumsphere from center is not defined."
             )
-        return Sphere(np.max(np.linalg.norm(self._vertices - center, axis=-1)), center)
+        return Sphere(np.max(np.linalg.norm(self.vertices - center, axis=-1)), center)

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -87,7 +87,7 @@ class ConvexSpheropolygon(Shape2D):
                    [ 0.,  1.,  0.]])
 
         """
-        self._polygon.reorder_verts(clockwise, ref_index, increasing_length)
+        self.polygon.reorder_verts(clockwise, ref_index, increasing_length)
 
     @property
     def polygon(self):
@@ -99,14 +99,14 @@ class ConvexSpheropolygon(Shape2D):
         """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
         return {
             "type": "Polygon",
-            "vertices": self._polygon._vertices.tolist(),
-            "rounding_radius": self._radius,
+            "vertices": self.polygon.vertices.tolist(),
+            "rounding_radius": self.radius,
         }
 
     @property
     def vertices(self):
         """:math:`(N_{verts}, 3)` :class:`numpy.ndarray` of float: Get the vertices of the spheropolygon."""  # noqa: E501
-        return self._polygon.vertices
+        return self.polygon.vertices
 
     @property
     def radius(self):
@@ -127,7 +127,7 @@ class ConvexSpheropolygon(Shape2D):
         The area is computed as the sum of the underlying polygon area and the
         area added by the rounding radius.
         """
-        poly_area = self._polygon.signed_area
+        poly_area = self.polygon.signed_area
 
         drs = self.vertices - np.roll(self.vertices, shift=-1, axis=0)
         edge_area = np.sum(np.linalg.norm(drs, axis=1)) * self.radius
@@ -160,16 +160,16 @@ class ConvexSpheropolygon(Shape2D):
     @property
     def center(self):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501
-        return self._polygon.center
+        return self.polygon.center
 
     @center.setter
     def center(self, value):
-        self._polygon.center = value
+        self.polygon.center = value
 
     @property
     def perimeter(self):
         """float: Get the perimeter of the spheropolygon."""
-        return self._polygon.perimeter + 2 * np.pi * self.radius
+        return self.polygon.perimeter + 2 * np.pi * self.radius
 
     @perimeter.setter
     def perimeter(self, value):

--- a/coxeter/shapes/convex_spheropolyhedron.py
+++ b/coxeter/shapes/convex_spheropolyhedron.py
@@ -78,8 +78,8 @@ class ConvexSpheropolyhedron(Shape3D):
         """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
         return {
             "type": "ConvexPolyhedron",
-            "vertices": self.polyhedron._vertices.tolist(),
-            "rounding_radius": self._radius,
+            "vertices": self.polyhedron.vertices.tolist(),
+            "rounding_radius": self.radius,
         }
 
     @property
@@ -90,16 +90,16 @@ class ConvexSpheropolyhedron(Shape3D):
     @property
     def vertices(self):
         """Get the vertices of the spheropolyhedron."""
-        return self._polyhedron.vertices
+        return self.polyhedron.vertices
 
     @property
     def center(self):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501
-        return self._polyhedron.center
+        return self.polyhedron.center
 
     @center.setter
     def center(self, value):
-        self._polyhedron.center = value
+        self.polyhedron.center = value
 
     @property
     def volume(self):
@@ -115,9 +115,9 @@ class ConvexSpheropolyhedron(Shape3D):
         # 4) The volume of the extruded faces, which is the surface area of
         #    each face multiplied by the rounding radius.
         v_poly = self.polyhedron.volume
-        v_sphere = (4 / 3) * np.pi * self._radius ** 3
+        v_sphere = (4 / 3) * np.pi * self.radius ** 3
         v_cyl = 0
-        v_face = self.polyhedron.surface_area * self._radius
+        v_face = self.polyhedron.surface_area * self.radius
 
         # For every pair of faces, find the dihedral angle, divide by 2*pi to
         # get the fraction of a cylinder it includes, then multiply by the edge
@@ -155,7 +155,7 @@ class ConvexSpheropolyhedron(Shape3D):
         #    angle of the face to determine what fraction of the cylinder to
         #    include.
         a_poly = self.polyhedron.surface_area
-        a_sphere = 4 * np.pi * self._radius ** 2
+        a_sphere = 4 * np.pi * self.radius ** 2
         a_cyl = 0
 
         # For every pair of faces, find the dihedral angle, divide by 2*pi to
@@ -296,8 +296,8 @@ class ConvexSpheropolyhedron(Shape3D):
         shape distinguishes this sphere from most typical circumsphere
         calculations.
         """  # noqa: E501
-        circumsphere = self._polyhedron.circumsphere_from_center
-        circumsphere.radius += self._radius
+        circumsphere = self.polyhedron.circumsphere_from_center
+        circumsphere.radius += self.radius
         return circumsphere
 
     @property
@@ -318,6 +318,6 @@ class ConvexSpheropolyhedron(Shape3D):
             >>> assert np.isclose(sphere.radius, 1.5)
 
         """
-        insphere = self._polyhedron.insphere_from_center
-        insphere.radius += self._radius
+        insphere = self.polyhedron.insphere_from_center
+        insphere.radius += self.radius
         return insphere

--- a/coxeter/shapes/ellipse.py
+++ b/coxeter/shapes/ellipse.py
@@ -46,18 +46,14 @@ class Ellipse(Shape2D):
     """
 
     def __init__(self, a, b, center=(0, 0, 0)):
-        if a <= 0:
-            raise ValueError("a must be greater than zero.")
-        if b <= 0:
-            raise ValueError("b must be greater than zero.")
-        self._a = a
-        self._b = b
-        self._center = np.asarray(center)
+        self.a = a
+        self.b = b
+        self.center = center
 
     @property
     def gsd_shape_spec(self):
         """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
-        return {"type": "Ellipsoid", "a": self._a, "b": self._b}
+        return {"type": "Ellipsoid", "a": self.a, "b": self.b}
 
     @property
     def center(self):

--- a/coxeter/shapes/ellipsoid.py
+++ b/coxeter/shapes/ellipsoid.py
@@ -53,12 +53,12 @@ class Ellipsoid(Shape3D):
         self.a = a
         self.b = b
         self.c = c
-        self._center = np.asarray(center)
+        self.center = center
 
     @property
     def gsd_shape_spec(self):
         """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
-        return {"type": "Ellipsoid", "a": self._a, "b": self._b, "c": self._c}
+        return {"type": "Ellipsoid", "a": self.a, "b": self.b, "c": self.c}
 
     @property
     def center(self):

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -238,7 +238,7 @@ class Polygon(Shape2D):
     @property
     def gsd_shape_spec(self):
         """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
-        return {"type": "Polygon", "vertices": self._vertices.tolist()}
+        return {"type": "Polygon", "vertices": self.vertices.tolist()}
 
     @property
     def normal(self):

--- a/coxeter/shapes/polyhedron.py
+++ b/coxeter/shapes/polyhedron.py
@@ -178,8 +178,8 @@ class Polyhedron(Shape3D):
         """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
         return {
             "type": "Mesh",
-            "vertices": self._vertices.tolist(),
-            "faces": self._faces,
+            "vertices": self.vertices.tolist(),
+            "faces": self.faces,
         }
 
     def merge_faces(self, atol=1e-8, rtol=1e-5):

--- a/coxeter/shapes/sphere.py
+++ b/coxeter/shapes/sphere.py
@@ -36,12 +36,12 @@ class Sphere(Shape3D):
 
     def __init__(self, radius, center=(0, 0, 0)):
         self.radius = radius
-        self._center = np.asarray(center)
+        self.center = center
 
     @property
     def gsd_shape_spec(self):
         """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
-        return {"type": "Sphere", "diameter": 2 * self._radius}
+        return {"type": "Sphere", "diameter": 2 * self.radius}
 
     @property
     def center(self):


### PR DESCRIPTION
## Description
This PR uses public properties everywhere possible.

## Motivation and Context
Public properties are validated when set and their names are shorter. All attributes that can be set should call the property setter in `__init__` instead of duplicating the validation logic in the constructor.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
