### PR TITLE
Rewrite tests to explicit reuse fixtures to avoid hypothesis errors.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -9,6 +9,12 @@ Added
 
 - Ellipse area setter and Ellipsoid volume setter.
 
+Changed
+~~~~~~~
+
+- Ensure that hypothesis-based tests don't implicitly reuse pytest fixtures.
+
+
 v0.4.0 - 2020-10-14
 -------------------
 

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -37,31 +37,43 @@ def test_2d_verts(square_points):
     ConvexSpheropolygon(square_points, 1)
 
 
-@given(r=floats(0.1, 1000))
-def test_radius_getter_setter(square_points, r):
+def test_radius_getter_setter(square_points):
     """Test getting and setting the radius."""
-    square_points = square_points[:, :2]
-    convexspheropolygon = ConvexSpheropolygon(square_points, r)
-    assert convexspheropolygon.radius == r
-    convexspheropolygon.radius = r + 1
-    assert convexspheropolygon.radius == r + 1
+
+    @given(r=floats(0.1, 1000))
+    def testfun(r):
+        square_points_2d = square_points[:, :2]
+        convexspheropolygon = ConvexSpheropolygon(square_points_2d, r)
+        assert convexspheropolygon.radius == r
+        convexspheropolygon.radius = r + 1
+        assert convexspheropolygon.radius == r + 1
+
+    testfun()
 
 
-@given(r=floats(-1000, -1))
-def test_invalid_radius_constructor(square_points, r):
+def test_invalid_radius_constructor(square_points):
     """Test invalid radius values in constructor."""
-    square_points = square_points[:, :2]
-    with pytest.raises(ValueError):
-        ConvexSpheropolygon(square_points, r)
+
+    @given(r=floats(-1000, -1))
+    def testfun(r):
+        square_points_2d = square_points[:, :2]
+        with pytest.raises(ValueError):
+            ConvexSpheropolygon(square_points_2d, r)
+
+    testfun()
 
 
-@given(r=floats(-1000, -1))
-def test_invalid_radius_setter(square_points, r):
+def test_invalid_radius_setter(square_points):
     """Test setting invalid radius values."""
-    square_points = square_points[:, :2]
-    spheropolygon = ConvexSpheropolygon(square_points, 1)
-    with pytest.raises(ValueError):
-        spheropolygon.radius = r
+
+    @given(r=floats(-1000, -1))
+    def testfun(r):
+        square_points_2d = square_points[:, :2]
+        spheropolygon = ConvexSpheropolygon(square_points_2d, 1)
+        with pytest.raises(ValueError):
+            spheropolygon.radius = r
+
+    testfun()
 
 
 def test_duplicate_points(square_points):
@@ -109,18 +121,22 @@ def test_area(unit_rounded_square):
     assert shape.area == area
 
 
-@given(area=floats(0.1, 1000))
-def test_area_getter_setter(unit_rounded_square, area):
+def test_area_getter_setter(unit_rounded_square):
     """Test setting the area."""
-    unit_rounded_square.area = area
-    assert unit_rounded_square.signed_area == approx(area)
-    assert unit_rounded_square.area == approx(area)
 
-    # Reset to original area
-    original_area = 1 + 4 + np.pi
-    unit_rounded_square.area = original_area
-    assert unit_rounded_square.signed_area == approx(original_area)
-    assert unit_rounded_square.area == approx(original_area)
+    @given(area=floats(0.1, 1000))
+    def testfun(area):
+        unit_rounded_square.area = area
+        assert unit_rounded_square.signed_area == approx(area)
+        assert unit_rounded_square.area == approx(area)
+
+        # Reset to original area
+        original_area = 1 + 4 + np.pi
+        unit_rounded_square.area = original_area
+        assert unit_rounded_square.signed_area == approx(original_area)
+        assert unit_rounded_square.area == approx(original_area)
+
+    testfun()
 
 
 def test_center(square_points, unit_rounded_square):
@@ -198,14 +214,18 @@ def test_sphero_square_perimeter(unit_rounded_square):
     assert unit_rounded_square.perimeter == 4 + 2 * np.pi
 
 
-@given(perimeter=floats(0.1, 1000))
-def test_perimeter_setter(unit_rounded_square, perimeter):
+def test_perimeter_setter(unit_rounded_square):
     """Test setting the perimeter."""
-    unit_rounded_square.perimeter = perimeter
-    assert unit_rounded_square.perimeter == approx(perimeter)
 
-    # Reset to original perimeter
-    original_perimeter = 4 + 2 * np.pi
-    unit_rounded_square.perimeter = original_perimeter
-    assert unit_rounded_square.perimeter == approx(original_perimeter)
-    assert unit_rounded_square.radius == approx(1.0)
+    @given(perimeter=floats(0.1, 1000))
+    def testfun(perimeter):
+        unit_rounded_square.perimeter = perimeter
+        assert unit_rounded_square.perimeter == approx(perimeter)
+
+        # Reset to original perimeter
+        original_perimeter = 4 + 2 * np.pi
+        unit_rounded_square.perimeter = original_perimeter
+        assert unit_rounded_square.perimeter == approx(original_perimeter)
+        assert unit_rounded_square.radius == approx(1.0)
+
+    testfun()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

This PR rewrites test that were implicitly reusing pytest fixtures to make this reuse explicit. I added a changelog entry since this may be important for others to track the reason for the failures.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

#122 added various tests that reuse pytest fixtures in hypothesis tests. Those tests would pass with warnings in older versions of hypothesis, but the [recent release of hypothesis 6.0.0 makes this an error](https://hypothesis.readthedocs.io/en/latest/changes.html#v6-0-0). These changes will avoid problems in the future.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
