### PR TITLE
Feature/bounding spheres

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -11,11 +11,20 @@ Added
 - Point-in-shape checks for circles.
 - Point-in-shape checks for ellipses.
 - Inertia tensors for 2D shapes that implement moments of inertia.
+- Add minimal bounding sphere for all shapes.
+- Add minimal centered bounding sphere calculations for all shapes except general polygons and polyhedra.
+- Enable getting and setting the circumsphere or bounding sphere radius of a polyhedron (for both types of bounding sphere).
 
 Changed
 ~~~~~~~
 
 - Ensure that hypothesis-based tests don't implicitly reuse pytest fixtures.
+
+Deprecated
+~~~~~~~
+
+- The circumsphere from center calculations (replaced by minimal centered bounding sphere).
+- The bounding_sphere property is deprecated in favor of minimal_bounding_sphere.
 
 
 v0.4.0 - 2020-10-14

--- a/Credits.rst
+++ b/Credits.rst
@@ -31,6 +31,9 @@ Vyas Ramasubramani - **Creator and lead developer**
 * Moved form factor amplitude calculations from legacy ft module to shape classes, cleaned and added more tests.
 * Added point-in-shape checks for circles and ellipses.
 * Added generic inertia tensors for 2D shapes.
+* Added minimal bounding sphere for all shapes.
+* Added minimal centered bounding sphere calculations for all shapes except general polygons and polyhedra.
+* Enabled getting and setting the circumsphere or bounding sphere radius of a polyhedron (for both types of bounding sphere).
 
 Bryan VanSaders - **Original maintainer of legacy euclid package**
 

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -154,6 +154,44 @@ class Shape2D(Shape):
         """  # noqa: E501
         return 4 * np.pi * self.area / (self.perimeter ** 2)
 
+    @property
+    def minimal_centered_bounding_circle(self):
+        """:class:`~.Circle`: Get a bounding circle sharing the center of this shape.
+
+        A `bounding circle <https://en.wikipedia.org/wiki/Polar_moment_of_inertia>`__
+        of a collection of points in :math:`n` dimensions is a circle containing
+        all of the points. There are an infinite set of possible bounding circles
+        for a shape (since any circle that entirely contains a bounding circle is
+        also a bounding circle), so additional constraints must be imposed to
+        define a unique circle. This property provides the smallest bounding circle
+        of a shape whose center coincides with the center of the shape.
+        """
+        # TODO: The definition of center in coxeter is currently under
+        # discussion and implementations of this property may have to be
+        # adapted accordingly, see
+        # https://github.com/glotzerlab/coxeter/issues/129
+        raise NotImplementedError(
+            "The minimal centered bounding circle calculation is not implemented "
+            "for this shape."
+        )
+
+    @property
+    def minimal_bounding_circle(self):
+        """:class:`~.Circle`: Get a bounding circle sharing the center of this shape.
+
+        A `bounding circle <https://en.wikipedia.org/wiki/Polar_moment_of_inertia>`__
+        of a collection of points in :math:`n` dimensions is a circle containing
+        all of the points. There are an infinite set of possible bounding circles
+        for a shape (since any circle that entirely contains a bounding circle is
+        also a bounding circle), so additional constraints must be imposed to
+        define a unique circle. This property provides the smallest bounding circle
+        of a shape.
+        """
+        raise NotImplementedError(
+            "The minimal bounding circle calculation is not implemented for "
+            "this shape."
+        )
+
 
 class Shape3D(Shape):
     """An abstract representation of a shape in 3 dimensions."""
@@ -201,3 +239,41 @@ class Shape3D(Shape):
             \end{align}
         """  # noqa: E501
         return np.pi * 36 * self.volume ** 2 / (self.surface_area ** 3)
+
+    @property
+    def minimal_centered_bounding_sphere(self):
+        """:class:`~.Sphere`: Get a bounding sphere sharing the center of this shape.
+
+        A `bounding sphere <https://en.wikipedia.org/wiki/Polar_moment_of_inertia>`__
+        of a collection of points in is a sphere containing all of the points.
+        There are an infinite set of possible bounding spheres for a shape
+        (since any sphere that entirely contains a bounding sphere is also a
+        bounding sphere), so additional constraints must be imposed to define a
+        unique sphere. This property provides the smallest bounding sphere of a
+        shape whose center coincides with the center of the shape.
+        """
+        # TODO: The definition of center in coxeter is currently under
+        # discussion and implementations of this property may have to be
+        # adapted accordingly, see
+        # https://github.com/glotzerlab/coxeter/issues/129
+        raise NotImplementedError(
+            "The minimal centered bounding sphere calculation is not implemented "
+            "for this shape."
+        )
+
+    @property
+    def minimal_bounding_sphere(self):
+        """:class:`~.Sphere`: Get a bounding sphere sharing the center of this shape.
+
+        A `bounding sphere <https://en.wikipedia.org/wiki/Polar_moment_of_inertia>`__
+        of a collection of points in dimensions is a sphere containing all of
+        the points. There are an infinite set of possible bounding spheres for
+        a shape (since any sphere that entirely contains a bounding sphere is
+        also a bounding sphere), so additional constraints must be imposed to
+        define a unique sphere. This property provides the smallest bounding
+        sphere of a shape.
+        """
+        raise NotImplementedError(
+            "The minimal bounding sphere calculation is not implemented for "
+            "this shape."
+        )

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -187,6 +187,18 @@ class Shape2D(Shape):
             "this shape."
         )
 
+    @property
+    def minimal_bounding_circle_radius(self):
+        """float: Get or set the radius of the minimal bounding circle.
+
+        See :meth:`~.minimal_bounding_circle` for more information.
+        """
+        return self.minimal_bounding_circle.radius
+
+    @minimal_bounding_circle_radius.setter
+    def minimal_bounding_circle_radius(self, value):
+        self._rescale(value / self.minimal_bounding_circle_radius)
+
 
 class Shape3D(Shape):
     """An abstract representation of a shape in 3 dimensions."""
@@ -272,3 +284,15 @@ class Shape3D(Shape):
             "The minimal bounding sphere calculation is not implemented for "
             "this shape."
         )
+
+    @property
+    def minimal_bounding_sphere_radius(self):
+        """float: Get or set the radius of the minimal bounding sphere.
+
+        See :meth:`~.minimal_bounding_sphere` for more information.
+        """
+        return self.minimal_bounding_sphere.radius
+
+    @minimal_bounding_sphere_radius.setter
+    def minimal_bounding_sphere_radius(self, value):
+        self._rescale(value / self.minimal_bounding_sphere_radius)

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -199,6 +199,18 @@ class Shape2D(Shape):
     def minimal_bounding_circle_radius(self, value):
         self._rescale(value / self.minimal_bounding_circle_radius)
 
+    @property
+    def minimal_centered_bounding_circle_radius(self):
+        """float: Get or set the radius of the minimal centered bounding circle.
+
+        See :meth:`~.minimal_centered_bounding_circle` for more information.
+        """
+        return self.minimal_centered_bounding_circle.radius
+
+    @minimal_centered_bounding_circle_radius.setter
+    def minimal_centered_bounding_circle_radius(self, value):
+        self._rescale(value / self.minimal_centered_bounding_circle_radius)
+
 
 class Shape3D(Shape):
     """An abstract representation of a shape in 3 dimensions."""
@@ -296,3 +308,15 @@ class Shape3D(Shape):
     @minimal_bounding_sphere_radius.setter
     def minimal_bounding_sphere_radius(self, value):
         self._rescale(value / self.minimal_bounding_sphere_radius)
+
+    @property
+    def minimal_centered_bounding_sphere_radius(self):
+        """float: Get or set the radius of the minimal concentric bounding sphere.
+
+        See :meth:`~.minimal_centered_bounding_sphere` for more information.
+        """
+        return self.minimal_centered_bounding_sphere.radius
+
+    @minimal_centered_bounding_sphere_radius.setter
+    def minimal_centered_bounding_sphere_radius(self, value):
+        self._rescale(value / self.minimal_centered_bounding_sphere_radius)

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -156,15 +156,11 @@ class Shape2D(Shape):
 
     @property
     def minimal_centered_bounding_circle(self):
-        """:class:`~.Circle`: Get a bounding circle sharing the center of this shape.
+        """:class:`~.Circle`: Get the smallest bounding concentric circle.
 
-        A `bounding circle <https://en.wikipedia.org/wiki/Polar_moment_of_inertia>`__
-        of a collection of points in :math:`n` dimensions is a circle containing
-        all of the points. There are an infinite set of possible bounding circles
-        for a shape (since any circle that entirely contains a bounding circle is
-        also a bounding circle), so additional constraints must be imposed to
-        define a unique circle. This property provides the smallest bounding circle
-        of a shape whose center coincides with the center of the shape.
+        This property gives the smallest
+        `bounding circle <https://en.wikipedia.org/wiki/Bounding_sphere>`__
+        whose center coincides with the center of the shape.
         """
         # TODO: The definition of center in coxeter is currently under
         # discussion and implementations of this property may have to be
@@ -177,15 +173,14 @@ class Shape2D(Shape):
 
     @property
     def minimal_bounding_circle(self):
-        """:class:`~.Circle`: Get a bounding circle sharing the center of this shape.
+        """:class:`~.Circle`: Get the smallset bounding circle.
 
-        A `bounding circle <https://en.wikipedia.org/wiki/Polar_moment_of_inertia>`__
-        of a collection of points in :math:`n` dimensions is a circle containing
-        all of the points. There are an infinite set of possible bounding circles
-        for a shape (since any circle that entirely contains a bounding circle is
-        also a bounding circle), so additional constraints must be imposed to
-        define a unique circle. This property provides the smallest bounding circle
-        of a shape.
+        A `bounding circle <https://en.wikipedia.org/wiki/Bounding_sphere>`__
+        in two dimensions is a circle containing all of the points. There are
+        an infinite set of possible bounding circles for a shape (since any
+        circle that entirely contains a bounding circle is also a bounding
+        circle), so additional constraints must be imposed to define a unique
+        circle. This property provides the smallest bounding circle of a shape.
         """
         raise NotImplementedError(
             "The minimal bounding circle calculation is not implemented for "

--- a/coxeter/shapes/circle.py
+++ b/coxeter/shapes/circle.py
@@ -160,9 +160,6 @@ class Circle(Shape2D):
         """
         return 1
 
-    def __eq__(self, other):
-        return self.radius == other.radius and self.center == other.center
-
     @property
     def minimal_centered_bounding_circle(self):
         """:class:`~.Circle`: Get the smallest bounding concentric circle."""

--- a/coxeter/shapes/circle.py
+++ b/coxeter/shapes/circle.py
@@ -159,3 +159,16 @@ class Circle(Shape2D):
         This is 1 by definition for circles.
         """
         return 1
+
+    def __eq__(self, other):
+        return self.radius == other.radius and self.center == other.center
+
+    @property
+    def minimal_centered_bounding_circle(self):
+        """:class:`~.Circle`: Get the smallest bounding concentric circle."""
+        return type(self)(self.radius, self.center)
+
+    @property
+    def minimal_bounding_circle(self):
+        """:class:`~.Circle`: Get the smallest bounding circle."""
+        return type(self)(self.radius, self.center)

--- a/coxeter/shapes/circle.py
+++ b/coxeter/shapes/circle.py
@@ -166,9 +166,9 @@ class Circle(Shape2D):
     @property
     def minimal_centered_bounding_circle(self):
         """:class:`~.Circle`: Get the smallest bounding concentric circle."""
-        return type(self)(self.radius, self.center)
+        return Circle(self.radius, self.center)
 
     @property
     def minimal_bounding_circle(self):
         """:class:`~.Circle`: Get the smallest bounding circle."""
-        return type(self)(self.radius, self.center)
+        return Circle(self.radius, self.center)

--- a/coxeter/shapes/convex_polygon.py
+++ b/coxeter/shapes/convex_polygon.py
@@ -64,7 +64,7 @@ class ConvexPolygon(Polygon):
         >>> import numpy as np
         >>> assert np.isclose(square.area, 4.0)
         >>> assert np.isclose(
-        ...   square.bounding_circle.radius,
+        ...   square.minimal_bounding_circle.radius,
         ...   np.sqrt(2.))
         >>> square.center
         array([0., 0., 0.])

--- a/coxeter/shapes/convex_polygon.py
+++ b/coxeter/shapes/convex_polygon.py
@@ -126,3 +126,11 @@ class ConvexPolygon(Polygon):
 
         radius = np.min(distances)
         return Circle(radius, self.center)
+
+    @property
+    def minimal_centered_bounding_circle(self):
+        """:class:`~.Circle`: Get the smallest bounding concentric circle."""
+        # The radius is determined by the furthest vertex from the center.
+        return Circle(
+            np.linalg.norm(self.vertices - self.center, axis=-1).max(), self.center
+        )

--- a/coxeter/shapes/convex_polyhedron.py
+++ b/coxeter/shapes/convex_polyhedron.py
@@ -1,5 +1,7 @@
 """Defines a convex polyhedron."""
 
+import warnings
+
 import numpy as np
 from scipy.spatial import ConvexHull
 
@@ -165,10 +167,23 @@ class ConvexPolyhedron(Polyhedron):
         shape distinguishes this sphere from most typical circumsphere
         calculations.
         """  # noqa: E501
+        warnings.warn(
+            "The circumsphere_from_center property is deprecated, use "
+            "minimal_centered_bounding_circle instead",
+            DeprecationWarning,
+        )
+        return self.minimal_centered_bounding_sphere
+
+    @property
+    def minimal_centered_bounding_sphere(self):
+        """:class:`~.Sphere`: Get the smallest bounding concentric sphere."""
+        # The radius is determined by the furthest vertex from the center.
         center = self.center
         if not self.is_inside(center):
             raise ValueError(
                 "The centroid is not contained in the shape. The "
                 "circumsphere from center is not defined."
             )
-        return Sphere(np.max(np.linalg.norm(self.vertices - center, axis=-1)), center)
+        return Sphere(
+            np.linalg.norm(self.vertices - self.center, axis=-1).max(), self.center
+        )

--- a/coxeter/shapes/convex_polyhedron.py
+++ b/coxeter/shapes/convex_polyhedron.py
@@ -28,7 +28,7 @@ class ConvexPolyhedron(Polyhedron):
         ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
         >>> import numpy as np
         >>> assert np.isclose(cube.asphericity, 1.5)
-        >>> bounding_sphere = cube.bounding_sphere
+        >>> bounding_sphere = cube.minimal_bounding_sphere
         >>> assert np.isclose(bounding_sphere.radius, np.sqrt(3))
         >>> cube.center
         array([0., 0., 0.])
@@ -169,7 +169,7 @@ class ConvexPolyhedron(Polyhedron):
         """  # noqa: E501
         warnings.warn(
             "The circumsphere_from_center property is deprecated, use "
-            "minimal_centered_bounding_circle instead",
+            "minimal_centered_bounding_sphere instead",
             DeprecationWarning,
         )
         return self.minimal_centered_bounding_sphere

--- a/coxeter/shapes/convex_polyhedron.py
+++ b/coxeter/shapes/convex_polyhedron.py
@@ -178,12 +178,6 @@ class ConvexPolyhedron(Polyhedron):
     def minimal_centered_bounding_sphere(self):
         """:class:`~.Sphere`: Get the smallest bounding concentric sphere."""
         # The radius is determined by the furthest vertex from the center.
-        center = self.center
-        if not self.is_inside(center):
-            raise ValueError(
-                "The centroid is not contained in the shape. The "
-                "circumsphere from center is not defined."
-            )
         return Sphere(
             np.linalg.norm(self.vertices - self.center, axis=-1).max(), self.center
         )

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -194,3 +194,9 @@ class ConvexSpheropolygon(Shape2D):
         """:class:`~.Circle`: Get the minimal bounding circle."""
         polygon_circle = self.polygon.minimal_bounding_circle
         return Circle(polygon_circle.radius + self.radius, polygon_circle.center)
+
+    @property
+    def minimal_centered_bounding_circle(self):
+        """:class:`~.Circle`: Get the minimal concentric bounding circle."""
+        polygon_circle = self.polygon.minimal_centered_bounding_circle
+        return Circle(polygon_circle.radius + self.radius, polygon_circle.center)

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -7,6 +7,7 @@ a circle of some radius.
 import numpy as np
 
 from .base_classes import Shape2D
+from .circle import Circle
 from .convex_polygon import ConvexPolygon, _is_convex
 
 
@@ -187,3 +188,9 @@ class ConvexSpheropolygon(Shape2D):
             self._rescale(scale)
         else:
             raise ValueError("Perimeter must be greater than zero.")
+
+    @property
+    def minimal_bounding_circle(self):
+        """:class:`~.Circle`: Get the minimal bounding circle."""
+        polygon_circle = self.polygon.minimal_bounding_circle
+        return Circle(polygon_circle.radius + self.radius, polygon_circle.center)

--- a/coxeter/shapes/convex_spheropolyhedron.py
+++ b/coxeter/shapes/convex_spheropolyhedron.py
@@ -349,5 +349,5 @@ class ConvexSpheropolyhedron(Shape3D):
     @property
     def minimal_bounding_sphere(self):
         """:class:`~.Sphere`: Get the minimal bounding sphere."""
-        polygon_sphere = self.polygon.minimal_bounding_sphere
-        return Sphere(polygon_sphere.radius + self.radius, polygon_sphere.center)
+        polyhedron_sphere = self.polyhedron.minimal_bounding_sphere
+        return Sphere(polyhedron_sphere.radius + self.radius, polyhedron_sphere.center)

--- a/coxeter/shapes/convex_spheropolyhedron.py
+++ b/coxeter/shapes/convex_spheropolyhedron.py
@@ -351,3 +351,9 @@ class ConvexSpheropolyhedron(Shape3D):
         """:class:`~.Sphere`: Get the minimal bounding sphere."""
         polyhedron_sphere = self.polyhedron.minimal_bounding_sphere
         return Sphere(polyhedron_sphere.radius + self.radius, polyhedron_sphere.center)
+
+    @property
+    def minimal_centered_bounding_sphere(self):
+        """:class:`~.Sphere`: Get the minimal concentric bounding sphere."""
+        polyhedron_sphere = self.polyhedron.minimal_concentric_bounding_sphere
+        return Sphere(polyhedron_sphere.radius + self.radius, polyhedron_sphere.center)

--- a/coxeter/shapes/convex_spheropolyhedron.py
+++ b/coxeter/shapes/convex_spheropolyhedron.py
@@ -4,6 +4,8 @@ A convex spheropolyhedron is defined by the Minkowski sum of a convex
 polyhedron and a sphere of some radius.
 """
 
+import warnings
+
 import numpy as np
 
 from .base_classes import Shape3D
@@ -32,7 +34,7 @@ class ConvexSpheropolyhedron(Shape3D):
         ...   radius=0.5)
         >>> spherocube.center
         array([0., 0., 0.])
-        >>> sphere = spherocube.circumsphere_from_center
+        >>> sphere = spherocube.minimal_centered_bounding_sphere
         >>> sphere.radius
         2.2320...
         >>> spherocube.gsd_shape_spec
@@ -320,9 +322,12 @@ class ConvexSpheropolyhedron(Shape3D):
         shape distinguishes this sphere from most typical circumsphere
         calculations.
         """  # noqa: E501
-        circumsphere = self.polyhedron.circumsphere_from_center
-        circumsphere.radius += self.radius
-        return circumsphere
+        warnings.warn(
+            "The circumsphere_from_center property is deprecated, use "
+            "minimal_centered_bounding_sphere instead",
+            DeprecationWarning,
+        )
+        return self.minimal_centered_bounding_sphere
 
     @property
     def insphere_from_center(self):
@@ -355,5 +360,5 @@ class ConvexSpheropolyhedron(Shape3D):
     @property
     def minimal_centered_bounding_sphere(self):
         """:class:`~.Sphere`: Get the minimal concentric bounding sphere."""
-        polyhedron_sphere = self.polyhedron.minimal_concentric_bounding_sphere
+        polyhedron_sphere = self.polyhedron.minimal_centered_bounding_sphere
         return Sphere(polyhedron_sphere.radius + self.radius, polyhedron_sphere.center)

--- a/coxeter/shapes/convex_spheropolyhedron.py
+++ b/coxeter/shapes/convex_spheropolyhedron.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from .base_classes import Shape3D
 from .convex_polyhedron import ConvexPolyhedron
+from .sphere import Sphere
 
 
 class ConvexSpheropolyhedron(Shape3D):
@@ -344,3 +345,9 @@ class ConvexSpheropolyhedron(Shape3D):
         insphere = self.polyhedron.insphere_from_center
         insphere.radius += self.radius
         return insphere
+
+    @property
+    def minimal_bounding_sphere(self):
+        """:class:`~.Sphere`: Get the minimal bounding sphere."""
+        polygon_sphere = self.polygon.minimal_bounding_sphere
+        return Sphere(polygon_sphere.radius + self.radius, polygon_sphere.center)

--- a/coxeter/shapes/ellipse.py
+++ b/coxeter/shapes/ellipse.py
@@ -3,7 +3,7 @@
 import numpy as np
 from scipy.special import ellipe
 
-from .base_classes import Shape2D
+from . import Circle, Shape2D
 
 
 class Ellipse(Shape2D):
@@ -191,3 +191,13 @@ class Ellipse(Shape2D):
     def iq(self):
         """float: The isoperimetric quotient."""
         return np.min([4 * np.pi * self.area / (self.perimeter ** 2), 1])
+
+    @property
+    def minimal_centered_bounding_circle(self):
+        """:class:`~.Circle`: Get the smallest bounding concentric circle."""
+        return Circle(max(self.a, self.b), self.center)
+
+    @property
+    def minimal_bounding_circle(self):
+        """:class:`~.Circle`: Get the smallest bounding circle."""
+        return Circle(max(self.a, self.b), self.center)

--- a/coxeter/shapes/ellipsoid.py
+++ b/coxeter/shapes/ellipsoid.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.special import ellipeinc, ellipkinc
 
 from .base_classes import Shape3D
+from .sphere import Sphere
 from .utils import translate_inertia_tensor
 
 
@@ -194,3 +195,13 @@ class Ellipsoid(Shape3D):
         points = np.atleast_2d(points) - self.center
         scale = np.array([self.a, self.b, self.c])
         return np.linalg.norm(points / scale, axis=-1) <= 1
+
+    @property
+    def minimal_centered_bounding_sphere(self):
+        """:class:`~.Sphere`: Get the smallest bounding concentric sphere."""
+        return Sphere(max(self.a, self.b, self.c), self.center)
+
+    @property
+    def minimal_bounding_sphere(self):
+        """:class:`~.Sphere`: Get the smallest bounding sphere."""
+        return Sphere(max(self.a, self.b, self.c), self.center)

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -562,6 +562,15 @@ class Polygon(Shape2D):
 
         return Circle(np.linalg.norm(x), x + self.vertices[0])
 
+    @property
+    def circumcircle_radius(self):
+        """float: Get the radius of the polygon's circumcircle."""
+        return self.circumcircle.radius
+
+    @circumcircle_radius.setter
+    def circumcircle_radius(self, value):
+        self._rescale(value / self.circumcircle_radius)
+
     def compute_form_factor_amplitude(self, q, density=1.0):  # noqa: D102
         """Calculate the form factor intensity.
 

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -98,7 +98,7 @@ class Polygon(Shape2D):
         >>> triangle = coxeter.shapes.Polygon([[-1, 0], [0, 1], [1, 0]])
         >>> import numpy as np
         >>> assert np.isclose(triangle.area, 1.0)
-        >>> bounding_circle = triangle.bounding_circle
+        >>> bounding_circle = triangle.minimal_bounding_circle
         >>> assert np.isclose(bounding_circle.radius, 1.0)
         >>> assert np.allclose(triangle.center, [0., 1. / 3., 0.])
         >>> circumcircle = triangle.circumcircle

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -1,5 +1,7 @@
 """Defines a polygon."""
 
+import warnings
+
 import numpy as np
 import rowan
 
@@ -488,6 +490,17 @@ class Polygon(Shape2D):
 
     @property
     def bounding_circle(self):
+        """:class:`~.Circle`: Get the minimal bounding circle."""
+        warnings.warn(
+            "The bounding_circle property is deprecated, use "
+            "minimal_bounding_circle instead",
+            DeprecationWarning,
+        )
+
+        return self.minimal_bounding_circle
+
+    @property
+    def minimal_bounding_circle(self):
         """:class:`~.Circle`: Get the minimal bounding circle."""
         if not MINIBALL:
             raise ImportError(

--- a/coxeter/shapes/polyhedron.py
+++ b/coxeter/shapes/polyhedron.py
@@ -69,7 +69,7 @@ class Polyhedron(Shape3D):
         ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]])
         >>> cube = coxeter.shapes.Polyhedron(
         ...   vertices=cube.vertices, faces=cube.faces)
-        >>> bounding_sphere = cube.bounding_sphere
+        >>> bounding_sphere = cube.minimal_bounding_sphere
         >>> import numpy as np
         >>> assert np.isclose(bounding_sphere.radius, np.sqrt(3))
         >>> cube.center

--- a/coxeter/shapes/polyhedron.py
+++ b/coxeter/shapes/polyhedron.py
@@ -1,5 +1,7 @@
 """Defines a polyhedron."""
 
+import warnings
+
 import numpy as np
 import rowan
 from scipy.sparse.csgraph import connected_components
@@ -500,6 +502,17 @@ class Polyhedron(Shape3D):
 
     @property
     def bounding_sphere(self):
+        """:class:`~.Sphere`: Get the polyhedron's bounding sphere."""
+        warnings.warn(
+            "The bounding_sphere property is deprecated, use "
+            "minimal_bounding_sphere instead",
+            DeprecationWarning,
+        )
+
+        return self.minimal_bounding_sphere
+
+    @property
+    def minimal_bounding_sphere(self):
         """:class:`~.Sphere`: Get the polyhedron's bounding sphere."""
         if not MINIBALL:
             raise ImportError(

--- a/coxeter/shapes/polyhedron.py
+++ b/coxeter/shapes/polyhedron.py
@@ -556,6 +556,15 @@ class Polyhedron(Shape3D):
 
         return Sphere(np.linalg.norm(x), x + self.vertices[0])
 
+    @property
+    def circumsphere_radius(self):
+        """float: Get the radius of the polygon's circumsphere."""
+        return self.circumsphere.radius
+
+    @circumsphere_radius.setter
+    def circumsphere_radius(self, value):
+        self._rescale(value / self.circumsphere_radius)
+
     def get_dihedral(self, a, b):
         """Get the dihedral angle between a pair of faces.
 

--- a/coxeter/shapes/sphere.py
+++ b/coxeter/shapes/sphere.py
@@ -165,3 +165,16 @@ class Sphere(Shape3D):
         # Shift the form factor to the particle's position and scale by density.
         form_factor *= density * np.exp(-1j * np.dot(q, self.center))
         return form_factor
+
+    def __eq__(self, other):
+        return self.radius == other.radius and self.center == other.center
+
+    @property
+    def minimal_centered_bounding_sphere(self):
+        """:class:`~.Sphere`: Get the smallest bounding concentric sphere."""
+        return Sphere(self.radius, self.center)
+
+    @property
+    def minimal_bounding_sphere(self):
+        """:class:`~.Sphere`: Get the smallest bounding sphere."""
+        return Sphere(self.radius, self.center)

--- a/coxeter/shapes/sphere.py
+++ b/coxeter/shapes/sphere.py
@@ -166,9 +166,6 @@ class Sphere(Shape3D):
         form_factor *= density * np.exp(-1j * np.dot(q, self.center))
         return form_factor
 
-    def __eq__(self, other):
-        return self.radius == other.radius and self.center == other.center
-
     @property
     def minimal_centered_bounding_sphere(self):
         """:class:`~.Sphere`: Get the smallest bounding concentric sphere."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,16 +138,15 @@ def platonic_solids():
         yield PlatonicFamily.get_shape(shape_name)
 
 
-def _test_get_set_minimal_bounding_sphere_radius(shape):
+def _test_get_set_minimal_bounding_sphere_radius(shape, centered=False):
     """Test getting and setting the minimal bounding circle radius.
 
     This function will work for any shape in two or three dimensions based on
     the generic base class APIs, so it can be called in other pytest tests.
     """
-    if isinstance(shape, Shape2D):
-        attr = "minimal_bounding_circle"
-    else:
-        attr = "minimal_bounding_sphere"
+    base_attr = "minimal" + ("_centered_" if centered else "_")
+    sphere_type = "circle" if isinstance(shape, Shape2D) else "sphere"
+    attr = base_attr + "bounding_" + sphere_type
 
     bounding_sphere = getattr(shape, attr)
     bounding_sphere_radius = getattr(shape, attr + "_radius")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,10 +120,11 @@ EllipseSurfaceStrategy = builds(
 )
 
 
-def circle_isclose(c1, c2, *args, **kwargs):
-    """Check if two circles are almost equal.
+def sphere_isclose(c1, c2, *args, **kwargs):
+    """Check if two spheres are almost equal.
 
-    All args and kwargs are forwarded to np.isclose and np.allclose.
+    Works for both circles and spheres. All args and kwargs are forwarded to
+    np.isclose and np.allclose.
     """
     return np.isclose(c1.radius, c2.radius, *args, **kwargs) and np.allclose(
         c1.center, c2.center, *args, **kwargs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from hypothesis.strategies import builds, floats, integers
 
+from coxeter.families import PlatonicFamily
 from coxeter.shapes import ConvexPolyhedron, ConvexSpheropolyhedron, Polyhedron
 
 
@@ -129,3 +130,8 @@ def sphere_isclose(c1, c2, *args, **kwargs):
     return np.isclose(c1.radius, c2.radius, *args, **kwargs) and np.allclose(
         c1.center, c2.center, *args, **kwargs
     )
+
+
+def platonic_solids():
+    for shape_name in PlatonicFamily.data:
+        yield PlatonicFamily.get_shape(shape_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,3 +118,13 @@ EllipsoidSurfaceStrategy = builds(
 EllipseSurfaceStrategy = builds(
     points_from_ellipsoid_surface, floats(0.1, 5), floats(0.1, 5), n=integers(5, 15)
 )
+
+
+def circle_isclose(c1, c2, *args, **kwargs):
+    """Check if two circles are almost equal.
+
+    All args and kwargs are forwarded to np.isclose and np.allclose.
+    """
+    return np.isclose(c1.radius, c2.radius, *args, **kwargs) and np.allclose(
+        c1.center, c2.center, *args, **kwargs
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from hypothesis.strategies import builds, floats, integers
 
 from coxeter.families import PlatonicFamily
-from coxeter.shapes import ConvexPolyhedron, ConvexSpheropolyhedron, Polyhedron
+from coxeter.shapes import ConvexPolyhedron, ConvexSpheropolyhedron, Polyhedron, Shape2D
 
 
 # Need to declare this outside the fixture so that it can be used in multiple
@@ -133,5 +133,25 @@ def sphere_isclose(c1, c2, *args, **kwargs):
 
 
 def platonic_solids():
+    """Generate platonic solids."""
     for shape_name in PlatonicFamily.data:
         yield PlatonicFamily.get_shape(shape_name)
+
+
+def _test_get_set_minimal_bounding_sphere_radius(shape):
+    """Test getting and setting the minimal bounding circle radius.
+
+    This function will work for any shape in two or three dimensions based on
+    the generic base class APIs, so it can be called in other pytest tests.
+    """
+    if isinstance(shape, Shape2D):
+        attr = "minimal_bounding_circle"
+    else:
+        attr = "minimal_bounding_sphere"
+
+    bounding_sphere = getattr(shape, attr)
+    bounding_sphere_radius = getattr(shape, attr + "_radius")
+
+    assert np.isclose(bounding_sphere_radius, bounding_sphere.radius)
+    setattr(shape, attr + "_radius", bounding_sphere_radius * 2)
+    assert np.isclose(getattr(shape, attr).radius, bounding_sphere_radius * 2)

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -109,3 +109,21 @@ def test_invalid_radius_setter():
     circle = Circle(1)
     with pytest.raises(ValueError):
         circle.radius = -1
+
+
+@given(
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_minimal_bounding_circle(r, center):
+    circ = Circle(r, center)
+    circ.minimal_bounding_circle == circ
+
+
+@given(
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_minimal_centered_bounding_circle(r, center):
+    circ = Circle(r, center)
+    circ.minimal_bounding_circle == circ

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -5,7 +5,7 @@ from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
 from pytest import approx
 
-from coxeter.shapes.circle import Circle
+from coxeter.shapes import Circle
 
 
 @given(floats(0.1, 1000))

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -5,6 +5,7 @@ from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
 from pytest import approx
 
+from conftest import sphere_isclose
 from coxeter.shapes import Circle
 
 
@@ -117,7 +118,7 @@ def test_invalid_radius_setter():
 )
 def test_minimal_bounding_circle(r, center):
     circ = Circle(r, center)
-    circ.minimal_bounding_circle == circ
+    assert sphere_isclose(circ.minimal_centered_bounding_circle, circ)
 
 
 @given(
@@ -126,4 +127,4 @@ def test_minimal_bounding_circle(r, center):
 )
 def test_minimal_centered_bounding_circle(r, center):
     circ = Circle(r, center)
-    circ.minimal_centered_bounding_circle == circ
+    assert sphere_isclose(circ.minimal_centered_bounding_circle, circ)

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -5,7 +5,7 @@ from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
 from pytest import approx
 
-from conftest import sphere_isclose
+from conftest import _test_get_set_minimal_bounding_sphere_radius, sphere_isclose
 from coxeter.shapes import Circle
 
 
@@ -128,3 +128,11 @@ def test_minimal_bounding_circle(r, center):
 def test_minimal_centered_bounding_circle(r, center):
     circ = Circle(r, center)
     assert sphere_isclose(circ.minimal_centered_bounding_circle, circ)
+
+
+@given(
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_get_set_minimal_bounding_circle_radius(r, center):
+    _test_get_set_minimal_bounding_sphere_radius(Circle(r, center))

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -136,3 +136,11 @@ def test_minimal_centered_bounding_circle(r, center):
 )
 def test_get_set_minimal_bounding_circle_radius(r, center):
     _test_get_set_minimal_bounding_sphere_radius(Circle(r, center))
+
+
+@given(
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_get_set_minimal_centered_bounding_circle_radius(r, center):
+    _test_get_set_minimal_bounding_sphere_radius(Circle(r, center), True)

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -126,4 +126,4 @@ def test_minimal_bounding_circle(r, center):
 )
 def test_minimal_centered_bounding_circle(r, center):
     circ = Circle(r, center)
-    circ.minimal_bounding_circle == circ
+    circ.minimal_centered_bounding_circle == circ

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -5,7 +5,7 @@ from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
 from pytest import approx
 
-from conftest import sphere_isclose
+from conftest import _test_get_set_minimal_bounding_sphere_radius, sphere_isclose
 from coxeter.shapes import Circle, Ellipse
 
 
@@ -168,3 +168,12 @@ def test_minimal_centered_bounding_circle(a, b, center):
     ellipse = Ellipse(a, b, center)
     bounding_circle = ellipse.minimal_centered_bounding_circle
     assert sphere_isclose(bounding_circle, Circle(max(a, b), center))
+
+
+@given(
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_get_set_minimal_bounding_ellipse_radius(a, b, center):
+    _test_get_set_minimal_bounding_sphere_radius(Ellipse(a, b, center))

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -165,5 +165,5 @@ def test_minimal_bounding_circle(a, b, center):
 )
 def test_minimal_centered_bounding_circle(a, b, center):
     ellipse = Ellipse(a, b, center)
-    bounding_circle = ellipse.minimal_bounding_circle
+    bounding_circle = ellipse.minimal_centered_bounding_circle
     bounding_circle == Circle(max(a, b), center)

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -5,6 +5,7 @@ from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
 from pytest import approx
 
+from conftest import sphere_isclose
 from coxeter.shapes import Circle, Ellipse
 
 
@@ -155,7 +156,7 @@ def test_center():
 def test_minimal_bounding_circle(a, b, center):
     ellipse = Ellipse(a, b, center)
     bounding_circle = ellipse.minimal_bounding_circle
-    bounding_circle == Circle(max(a, b), center)
+    assert sphere_isclose(bounding_circle, Circle(max(a, b), center))
 
 
 @given(
@@ -166,4 +167,4 @@ def test_minimal_bounding_circle(a, b, center):
 def test_minimal_centered_bounding_circle(a, b, center):
     ellipse = Ellipse(a, b, center)
     bounding_circle = ellipse.minimal_centered_bounding_circle
-    bounding_circle == Circle(max(a, b), center)
+    assert sphere_isclose(bounding_circle, Circle(max(a, b), center))

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -177,3 +177,12 @@ def test_minimal_centered_bounding_circle(a, b, center):
 )
 def test_get_set_minimal_bounding_ellipse_radius(a, b, center):
     _test_get_set_minimal_bounding_sphere_radius(Ellipse(a, b, center))
+
+
+@given(
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_get_set_minimal_centered_bounding_ellipse_radius(a, b, center):
+    _test_get_set_minimal_bounding_sphere_radius(Ellipse(a, b, center), True)

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -5,7 +5,7 @@ from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
 from pytest import approx
 
-from coxeter.shapes.ellipse import Ellipse
+from coxeter.shapes import Circle, Ellipse
 
 
 @given(floats(0.1, 1000), floats(0.1, 1000))
@@ -124,6 +124,8 @@ def test_inertia_tensor(a, b, center):
     ellipse = Ellipse(a, b)
     assert np.all(np.asarray(ellipse.planar_moments_inertia) >= 0)
 
+    # We must set the center after construction so that the inertia tensor
+    # calculation is not shifted away from the origin.
     ellipse.center = center
     area = ellipse.area
     expected = [np.pi / 4 * a * b ** 3, np.pi / 4 * a ** 3 * b, 0]
@@ -143,3 +145,25 @@ def test_center():
     center = (1, 1, 1)
     ellipse.center = center
     assert all(ellipse.center == center)
+
+
+@given(
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_minimal_bounding_circle(a, b, center):
+    ellipse = Ellipse(a, b, center)
+    bounding_circle = ellipse.minimal_bounding_circle
+    bounding_circle == Circle(max(a, b), center)
+
+
+@given(
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_minimal_centered_bounding_circle(a, b, center):
+    ellipse = Ellipse(a, b, center)
+    bounding_circle = ellipse.minimal_bounding_circle
+    bounding_circle == Circle(max(a, b), center)

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -5,7 +5,7 @@ from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
 from pytest import approx
 
-from coxeter.shapes.ellipsoid import Ellipsoid
+from coxeter.shapes import Ellipsoid, Sphere
 from coxeter.shapes.utils import translate_inertia_tensor
 
 
@@ -175,3 +175,27 @@ def test_center():
     center = (1, 1, 1)
     ellipsoid.center = center
     assert all(ellipsoid.center == center)
+
+
+@given(
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_minimal_bounding_sphere(a, b, c, center):
+    ellipsoid = Ellipsoid(a, b, c, center)
+    bounding_sphere = ellipsoid.minimal_bounding_sphere
+    bounding_sphere == Sphere(max(a, b, c), center)
+
+
+@given(
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_minimal_centered_bounding_sphere(a, b, c, center):
+    ellipsoid = Ellipsoid(a, b, c, center)
+    bounding_sphere = ellipsoid.minimal_centered_bounding_sphere
+    bounding_sphere == Sphere(max(a, b, c), center)

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -5,6 +5,7 @@ from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
 from pytest import approx
 
+from conftest import sphere_isclose
 from coxeter.shapes import Ellipsoid, Sphere
 from coxeter.shapes.utils import translate_inertia_tensor
 
@@ -186,7 +187,7 @@ def test_center():
 def test_minimal_bounding_sphere(a, b, c, center):
     ellipsoid = Ellipsoid(a, b, c, center)
     bounding_sphere = ellipsoid.minimal_bounding_sphere
-    bounding_sphere == Sphere(max(a, b, c), center)
+    sphere_isclose(bounding_sphere, Sphere(max(a, b, c), center))
 
 
 @given(
@@ -198,4 +199,4 @@ def test_minimal_bounding_sphere(a, b, c, center):
 def test_minimal_centered_bounding_sphere(a, b, c, center):
     ellipsoid = Ellipsoid(a, b, c, center)
     bounding_sphere = ellipsoid.minimal_centered_bounding_sphere
-    bounding_sphere == Sphere(max(a, b, c), center)
+    sphere_isclose(bounding_sphere, Sphere(max(a, b, c), center))

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -5,7 +5,7 @@ from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
 from pytest import approx
 
-from conftest import sphere_isclose
+from conftest import _test_get_set_minimal_bounding_sphere_radius, sphere_isclose
 from coxeter.shapes import Ellipsoid, Sphere
 from coxeter.shapes.utils import translate_inertia_tensor
 
@@ -200,3 +200,13 @@ def test_minimal_centered_bounding_sphere(a, b, c, center):
     ellipsoid = Ellipsoid(a, b, c, center)
     bounding_sphere = ellipsoid.minimal_centered_bounding_sphere
     sphere_isclose(bounding_sphere, Sphere(max(a, b, c), center))
+
+
+@given(
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_get_set_minimal_bounding_circle_radius(a, b, c, center):
+    _test_get_set_minimal_bounding_sphere_radius(Ellipsoid(a, b, c, center))

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -210,3 +210,13 @@ def test_minimal_centered_bounding_sphere(a, b, c, center):
 )
 def test_get_set_minimal_bounding_circle_radius(a, b, c, center):
     _test_get_set_minimal_bounding_sphere_radius(Ellipsoid(a, b, c, center))
+
+
+@given(
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_get_set_minimal_centered_bounding_circle_radius(a, b, c, center):
+    _test_get_set_minimal_bounding_sphere_radius(Ellipsoid(a, b, c, center), True)

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -403,6 +403,12 @@ def test_get_set_minimal_bounding_circle_radius():
         _test_get_set_minimal_bounding_sphere_radius(family.get_shape(i))
 
 
+def test_get_set_minimal_centered_bounding_circle_radius():
+    family = RegularNGonFamily()
+    for i in range(3, 10):
+        _test_get_set_minimal_bounding_sphere_radius(family.get_shape(i), True)
+
+
 def test_minimal_centered_bounding_circle():
     family = RegularNGonFamily()
     for i in range(3, 10):

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -14,8 +14,7 @@ from conftest import (
     sphere_isclose,
 )
 from coxeter.families import RegularNGonFamily
-from coxeter.shapes.convex_polygon import ConvexPolygon
-from coxeter.shapes.polygon import Polygon
+from coxeter.shapes import Circle, ConvexPolygon, Polygon
 
 
 def polygon_from_hull(verts):
@@ -402,3 +401,12 @@ def test_get_set_minimal_bounding_circle_radius():
     family = RegularNGonFamily()
     for i in range(3, 10):
         _test_get_set_minimal_bounding_sphere_radius(family.get_shape(i))
+
+
+def test_minimal_centered_bounding_circle():
+    family = RegularNGonFamily()
+    for i in range(3, 10):
+        poly = family.get_shape(i)
+        poly.minimal_centered_bounding_circle == Circle(
+            np.linalg.norm(poly.vertices, axis=-1).max()
+        )

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -316,6 +316,19 @@ def test_circumcircle():
         assert np.allclose(circle.center, 0)
 
 
+def test_circumcircle_radius():
+    family = RegularNGonFamily()
+    for i in range(3, 10):
+        vertices = family.make_vertices(i)
+        rmax = np.max(np.linalg.norm(vertices, axis=-1))
+
+        poly = Polygon(vertices)
+
+        assert np.isclose(rmax, poly.circumcircle_radius)
+        poly.circumcircle_radius *= 2
+        assert np.isclose(poly.circumcircle.radius, rmax * 2)
+
+
 def test_incircle_from_center(convex_square):
     circle = convex_square.incircle_from_center
     assert np.all(circle.center == convex_square.center)

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -426,6 +426,7 @@ def test_minimal_centered_bounding_circle():
     family = RegularNGonFamily()
     for i in range(3, 10):
         poly = family.get_shape(i)
-        poly.minimal_centered_bounding_circle == Circle(
-            np.linalg.norm(poly.vertices, axis=-1).max()
+        assert sphere_isclose(
+            poly.minimal_centered_bounding_circle,
+            Circle(np.linalg.norm(poly.vertices, axis=-1).max()),
         )

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -8,7 +8,11 @@ from hypothesis.strategies import floats
 from pytest import approx
 from scipy.spatial import ConvexHull
 
-from conftest import EllipseSurfaceStrategy, sphere_isclose
+from conftest import (
+    EllipseSurfaceStrategy,
+    _test_get_set_minimal_bounding_sphere_radius,
+    sphere_isclose,
+)
 from coxeter.families import RegularNGonFamily
 from coxeter.shapes.convex_polygon import ConvexPolygon
 from coxeter.shapes.polygon import Polygon
@@ -392,3 +396,9 @@ def test_set_perimeter(value):
         RegularNGonFamily.get_shape(4).vertices
         * (value / RegularNGonFamily.get_shape(4).perimeter)
     )
+
+
+def test_get_set_minimal_bounding_circle_radius():
+    family = RegularNGonFamily()
+    for i in range(3, 10):
+        _test_get_set_minimal_bounding_sphere_radius(family.get_shape(i))

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -8,7 +8,7 @@ from hypothesis.strategies import floats
 from pytest import approx
 from scipy.spatial import ConvexHull
 
-from conftest import EllipseSurfaceStrategy, circle_isclose
+from conftest import EllipseSurfaceStrategy, sphere_isclose
 from coxeter.families import RegularNGonFamily
 from coxeter.shapes.convex_polygon import ConvexPolygon
 from coxeter.shapes.polygon import Polygon
@@ -259,7 +259,7 @@ def test_minimal_bounding_circle_radius_regular_polygon():
         assert np.allclose(circle.center, 0)
 
         with pytest.deprecated_call():
-            assert circle_isclose(circle, poly.bounding_circle)
+            assert sphere_isclose(circle, poly.bounding_circle)
 
 
 @given(EllipseSurfaceStrategy)

--- a/tests/test_polyhedron.py
+++ b/tests/test_polyhedron.py
@@ -280,6 +280,17 @@ def test_circumsphere_platonic(poly):
     assert np.allclose(r2, circumsphere.radius ** 2)
 
 
+@pytest.mark.parametrize("poly", platonic_solids())
+def test_circumsphere_radius_platonic(poly):
+    # Ensure polyhedron is centered, then compute distances.
+    poly.center = [0, 0, 0]
+    r2 = np.sum(poly.vertices ** 2, axis=1)
+
+    assert np.allclose(r2, poly.circumsphere_radius ** 2)
+    poly.circumsphere_radius *= 2
+    assert np.allclose(r2 * 4, poly.circumsphere_radius ** 2)
+
+
 def test_minimal_centered_bounding_circle():
     """Validate circumsphere by testing the polyhedron.
 

--- a/tests/test_polyhedron.py
+++ b/tests/test_polyhedron.py
@@ -11,6 +11,7 @@ from scipy.spatial import ConvexHull
 
 from conftest import (
     EllipsoidSurfaceStrategy,
+    _test_get_set_minimal_bounding_sphere_radius,
     get_oriented_cube_faces,
     get_oriented_cube_normals,
     platonic_solids,
@@ -522,3 +523,8 @@ def test_form_factor(cube):
         ],
         atol=1e-7,
     )
+
+
+def test_get_set_minimal_bounding_sphere_radius():
+    for poly in platonic_solids():
+        _test_get_set_minimal_bounding_sphere_radius(poly)

--- a/tests/test_polyhedron.py
+++ b/tests/test_polyhedron.py
@@ -13,6 +13,7 @@ from conftest import (
     EllipsoidSurfaceStrategy,
     get_oriented_cube_faces,
     get_oriented_cube_normals,
+    platonic_solids,
     sphere_isclose,
 )
 from coxeter.families import DOI_SHAPE_REPOSITORIES, PlatonicFamily
@@ -29,11 +30,6 @@ def damasceno_shapes():
     family = DOI_SHAPE_REPOSITORIES["10.1126/science.1220869"][0]
     for shape_data in family.data.values():
         yield shape_data
-
-
-def platonic_solids():
-    for shape_name in PlatonicFamily.data:
-        yield PlatonicFamily.get_shape(shape_name)
 
 
 def test_normal_detection(convex_cube):

--- a/tests/test_polyhedron.py
+++ b/tests/test_polyhedron.py
@@ -280,7 +280,7 @@ def test_circumsphere_platonic(poly):
     assert np.allclose(r2, circumsphere.radius ** 2)
 
 
-def test_circumsphere_from_center():
+def test_minimal_centered_bounding_circle():
     """Validate circumsphere by testing the polyhedron.
 
     This checks that all points outside this circumsphere are also outside the
@@ -321,13 +321,16 @@ def test_circumsphere_from_center():
         poly = shapes[shape_index]
         poly.center = center
 
-        sphere = poly.circumsphere_from_center
+        sphere = poly.minimal_centered_bounding_sphere
         scaled_points = points * sphere.radius + sphere.center
         points_outside = np.logical_not(sphere.is_inside(scaled_points))
 
         # Verify that all points outside the circumsphere are also outside the
         # polyhedron.
         assert not np.any(np.logical_and(points_outside, poly.is_inside(scaled_points)))
+
+        with pytest.deprecated_call():
+            assert sphere_isclose(sphere, poly.circumsphere_from_center)
 
     testfun()
 

--- a/tests/test_polyhedron.py
+++ b/tests/test_polyhedron.py
@@ -13,6 +13,7 @@ from conftest import (
     EllipsoidSurfaceStrategy,
     get_oriented_cube_faces,
     get_oriented_cube_normals,
+    sphere_isclose,
 )
 from coxeter.families import DOI_SHAPE_REPOSITORIES, PlatonicFamily
 from coxeter.shapes.convex_polyhedron import ConvexPolyhedron
@@ -340,7 +341,11 @@ def test_bounding_sphere_platonic(poly):
     poly.center = [0, 0, 0]
     r2 = np.sum(poly.vertices ** 2, axis=1)
 
-    assert np.allclose(r2, poly.bounding_sphere.radius ** 2, rtol=1e-4)
+    bounding_sphere = poly.minimal_bounding_sphere
+    assert np.allclose(r2, bounding_sphere.radius ** 2, rtol=1e-4)
+
+    with pytest.deprecated_call():
+        assert sphere_isclose(bounding_sphere, poly.bounding_sphere)
 
 
 def test_inside_boundaries(convex_cube):

--- a/tests/test_polyhedron.py
+++ b/tests/test_polyhedron.py
@@ -531,3 +531,8 @@ def test_form_factor(cube):
 def test_get_set_minimal_bounding_sphere_radius():
     for poly in platonic_solids():
         _test_get_set_minimal_bounding_sphere_radius(poly)
+
+
+def test_get_set_minimal_centered_bounding_sphere_radius():
+    for poly in platonic_solids():
+        _test_get_set_minimal_bounding_sphere_radius(poly, True)

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -194,3 +194,11 @@ def test_minimal_centered_bounding_sphere(r, center):
 )
 def test_get_set_minimal_bounding_circle_radius(r, center):
     _test_get_set_minimal_bounding_sphere_radius(Sphere(r, center))
+
+
+@given(
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_get_set_minimal_centered_bounding_circle_radius(r, center):
+    _test_get_set_minimal_bounding_sphere_radius(Sphere(r, center), True)

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -183,5 +183,5 @@ def test_minimal_bounding_sphere(r, center):
 )
 def test_minimal_centered_bounding_sphere(r, center):
     sphere = Sphere(r, center)
-    bounding_sphere = sphere.minimal_bounding_sphere
+    bounding_sphere = sphere.minimal_centered_bounding_sphere
     bounding_sphere == Sphere(r, center)

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -5,7 +5,7 @@ from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
 from pytest import approx
 
-from coxeter.shapes.sphere import Sphere
+from coxeter.shapes import Sphere
 from coxeter.shapes.utils import translate_inertia_tensor
 
 
@@ -165,3 +165,23 @@ def test_form_factor():
         ],
         atol=1e-7,
     )
+
+
+@given(
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_minimal_bounding_sphere(r, center):
+    sphere = Sphere(r, center)
+    bounding_sphere = sphere.minimal_bounding_sphere
+    bounding_sphere == Sphere(r, center)
+
+
+@given(
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_minimal_centered_bounding_sphere(r, center):
+    sphere = Sphere(r, center)
+    bounding_sphere = sphere.minimal_bounding_sphere
+    bounding_sphere == Sphere(r, center)

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -5,7 +5,7 @@ from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
 from pytest import approx
 
-from conftest import sphere_isclose
+from conftest import _test_get_set_minimal_bounding_sphere_radius, sphere_isclose
 from coxeter.shapes import Sphere
 from coxeter.shapes.utils import translate_inertia_tensor
 
@@ -186,3 +186,11 @@ def test_minimal_centered_bounding_sphere(r, center):
     sphere = Sphere(r, center)
     bounding_sphere = sphere.minimal_centered_bounding_sphere
     assert sphere_isclose(bounding_sphere, Sphere(r, center))
+
+
+@given(
+    floats(0.1, 1000),
+    arrays(np.float64, (3,), elements=floats(-10, 10, width=64), unique=True),
+)
+def test_get_set_minimal_bounding_circle_radius(r, center):
+    _test_get_set_minimal_bounding_sphere_radius(Sphere(r, center))

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -5,6 +5,7 @@ from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
 from pytest import approx
 
+from conftest import sphere_isclose
 from coxeter.shapes import Sphere
 from coxeter.shapes.utils import translate_inertia_tensor
 
@@ -174,7 +175,7 @@ def test_form_factor():
 def test_minimal_bounding_sphere(r, center):
     sphere = Sphere(r, center)
     bounding_sphere = sphere.minimal_bounding_sphere
-    bounding_sphere == Sphere(r, center)
+    assert sphere_isclose(bounding_sphere, Sphere(r, center))
 
 
 @given(
@@ -184,4 +185,4 @@ def test_minimal_bounding_sphere(r, center):
 def test_minimal_centered_bounding_sphere(r, center):
     sphere = Sphere(r, center)
     bounding_sphere = sphere.minimal_centered_bounding_sphere
-    bounding_sphere == Sphere(r, center)
+    assert sphere_isclose(bounding_sphere, Sphere(r, center))

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -9,6 +9,7 @@ from pytest import approx
 from scipy.spatial import ConvexHull
 
 from conftest import EllipseSurfaceStrategy
+from coxeter.families import RegularNGonFamily
 from coxeter.shapes import ConvexSpheropolygon
 
 
@@ -229,3 +230,17 @@ def test_perimeter_setter(unit_rounded_square):
         assert unit_rounded_square.radius == approx(1.0)
 
     testfun()
+
+
+@given(floats(0.1, 1000))
+def test_minimal_bounding_circle_radius_regular_polygon(radius):
+    family = RegularNGonFamily()
+    for i in range(3, 10):
+        vertices = family.make_vertices(i)
+        rmax = np.max(np.linalg.norm(vertices, axis=-1)) + radius
+
+        poly = ConvexSpheropolygon(vertices, radius)
+        circle = poly.minimal_bounding_circle
+
+        assert np.isclose(rmax, circle.radius)
+        assert np.allclose(circle.center, 0)

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -236,7 +236,7 @@ def test_perimeter_setter(unit_rounded_square):
 
 
 @given(floats(0.1, 1000))
-def test_minimal_bounding_circle_radius_regular_polygon(radius):
+def test_minimal_bounding_circle_regular_polygon(radius):
     family = RegularNGonFamily()
     for i in range(3, 10):
         vertices = family.make_vertices(i)
@@ -244,6 +244,20 @@ def test_minimal_bounding_circle_radius_regular_polygon(radius):
 
         poly = ConvexSpheropolygon(vertices, radius)
         circle = poly.minimal_bounding_circle
+
+        assert np.isclose(rmax, circle.radius)
+        assert np.allclose(circle.center, 0)
+
+
+@given(floats(0.1, 1000))
+def test_minimal_centered_bounding_circle_regular_polygon(radius):
+    family = RegularNGonFamily()
+    for i in range(3, 10):
+        vertices = family.make_vertices(i)
+        rmax = np.max(np.linalg.norm(vertices, axis=-1)) + radius
+
+        poly = ConvexSpheropolygon(vertices, radius)
+        circle = poly.minimal_centered_bounding_circle
 
         assert np.isclose(rmax, circle.radius)
         assert np.allclose(circle.center, 0)

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -8,7 +8,10 @@ from hypothesis.strategies import floats
 from pytest import approx
 from scipy.spatial import ConvexHull
 
-from conftest import EllipseSurfaceStrategy
+from conftest import (
+    EllipseSurfaceStrategy,
+    _test_get_set_minimal_bounding_sphere_radius,
+)
 from coxeter.families import RegularNGonFamily
 from coxeter.shapes import ConvexSpheropolygon
 
@@ -244,3 +247,12 @@ def test_minimal_bounding_circle_radius_regular_polygon(radius):
 
         assert np.isclose(rmax, circle.radius)
         assert np.allclose(circle.center, 0)
+
+
+@given(floats(0.1, 1000))
+def test_get_set_minimal_bounding_circle_radius(r):
+    family = RegularNGonFamily()
+    for i in range(3, 10):
+        _test_get_set_minimal_bounding_sphere_radius(
+            ConvexSpheropolygon(family.make_vertices(i), r)
+        )

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -4,7 +4,8 @@ from hypothesis import given
 from hypothesis.strategies import floats
 from pytest import approx
 
-from conftest import make_sphero_cube
+from conftest import make_sphero_cube, platonic_solids
+from coxeter.shapes import ConvexSpheropolyhedron
 
 
 @given(radius=floats(0.1, 1))
@@ -119,3 +120,16 @@ def test_inside_boundaries():
     assert np.all(sphero_cube.is_inside(verts * (1 + 2 * np.sqrt(1 / 3))))
     # Points are just outside the very corners of the spherical caps
     assert np.all(~sphero_cube.is_inside(verts * (1 + 2 * np.sqrt(1 / 3) + 1e-6)))
+
+
+@pytest.mark.parametrize("poly", platonic_solids())
+def test_bounding_sphere_platonic(poly):
+    @given(floats(0.1, 1000))
+    def testfun(radius):
+        # Ensure polyhedron is centered, then compute distances.
+        spheropoly = ConvexSpheropolyhedron(poly.vertices, radius)
+        spheropoly.center = [0, 0, 0]
+        rmax_sq = np.sum(spheropoly.vertices ** 2, axis=1) + radius * radius
+
+        bounding_sphere = spheropoly.minimal_bounding_sphere
+        assert np.allclose(rmax_sq, bounding_sphere.radius ** 2, rtol=1e-4)

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -127,7 +127,7 @@ def test_inside_boundaries():
 
 
 @pytest.mark.parametrize("poly", platonic_solids())
-def test_bounding_sphere_platonic(poly):
+def test_minimal_bounding_sphere_platonic(poly):
     @given(floats(0.1, 1000))
     def testfun(radius):
         # Ensure polyhedron is centered, then compute distances.
@@ -136,6 +136,19 @@ def test_bounding_sphere_platonic(poly):
         rmax_sq = np.sum(spheropoly.vertices ** 2, axis=1) + radius * radius
 
         bounding_sphere = spheropoly.minimal_bounding_sphere
+        assert np.allclose(rmax_sq, bounding_sphere.radius ** 2, rtol=1e-4)
+
+
+@pytest.mark.parametrize("poly", platonic_solids())
+def test_minimal_centered_bounding_sphere_platonic(poly):
+    @given(floats(0.1, 1000))
+    def testfun(radius):
+        # Ensure polyhedron is centered, then compute distances.
+        spheropoly = ConvexSpheropolyhedron(poly.vertices, radius)
+        spheropoly.center = [0, 0, 0]
+        rmax_sq = np.sum(spheropoly.vertices ** 2, axis=1) + radius * radius
+
+        bounding_sphere = spheropoly.minimal_centered_bounding_sphere
         assert np.allclose(rmax_sq, bounding_sphere.radius ** 2, rtol=1e-4)
 
 

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -1,10 +1,14 @@
 import numpy as np
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.strategies import floats
 from pytest import approx
 
-from conftest import make_sphero_cube, platonic_solids
+from conftest import (
+    _test_get_set_minimal_bounding_sphere_radius,
+    make_sphero_cube,
+    platonic_solids,
+)
 from coxeter.shapes import ConvexSpheropolyhedron
 
 
@@ -133,3 +137,12 @@ def test_bounding_sphere_platonic(poly):
 
         bounding_sphere = spheropoly.minimal_bounding_sphere
         assert np.allclose(rmax_sq, bounding_sphere.radius ** 2, rtol=1e-4)
+
+
+@settings(deadline=500)
+@given(floats(0.1, 1))
+def test_get_set_minimal_bounding_sphere_radius(r):
+    for poly in platonic_solids():
+        _test_get_set_minimal_bounding_sphere_radius(
+            ConvexSpheropolyhedron(poly.vertices, r)
+        )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

Adds the ability compute both minimal and minimal centered bounding spheres for all shapes except general (not convex) polygons and polyhedra, for which 1) the centered calculation seems ill-defined given the possibility of the center not being contained within the shape, and 2) the is_inside check not being implemented to check for (1). Also deprecates some older properties in favor of more standard terminology: most of the literature (beyond our group's very ad hoc usage) avoids using circumsphere for anything other than polytopes, and "bounding sphere" by itself is too generic.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Filling out the feature matrix. Also helps improve API consistency with naming across shapes.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
