### PR TITLE
Require polygons to be in xy plane for some computations.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -28,6 +28,7 @@ Changed
 ~~~~~~~
 
 - Ensure that hypothesis-based tests don't implicitly reuse pytest fixtures.
+- Some properties of Polygon and ConvexSpheropolygon require the shape to be in the xy plane.
 
 Deprecated
 ~~~~~~~~~~

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -111,6 +111,15 @@ class Shape(ABC):
 class Shape2D(Shape):
     """An abstract representation of a shape in 2 dimensions."""
 
+    def _require_xy_plane(self):
+        """Enforce that the shape is embedded in the :math:`xy` plane."""
+        if not np.isclose(self.centroid[2], 0):
+            class_name = type(self).__name__
+            raise ValueError(
+                f"This method requires the {class_name} to be embedded in the xy "
+                f"plane. The centroid of this {class_name} is {self.centroid}."
+            )
+
     @property
     @abstractmethod
     def area(self):

--- a/coxeter/shapes/circle.py
+++ b/coxeter/shapes/circle.py
@@ -174,13 +174,17 @@ class Circle(Shape2D):
             array([ True, False])
 
         """
-        points = np.atleast_2d(points) - self.centroid
-        return np.logical_and(
-            np.linalg.norm(points, axis=-1) <= self.radius,
-            # At present circles are not orientable, so the z position must
-            # match exactly.
-            np.isclose(points[:, 2], 0),
-        )
+        self._require_xy_plane()
+        points = np.atleast_2d(points)
+        # For convenience, we support providing points without z components
+        if points.shape[1] == 2:
+            points = np.hstack((points, np.zeros((points.shape[0], 1))))
+        if not np.all(points[:, 2] == 0):
+            raise ValueError(
+                "All provided points must be in the xy plane (points[:, 2] == 0)."
+            )
+
+        return np.linalg.norm(points, axis=-1) <= self.radius
 
     @property
     def iq(self):

--- a/coxeter/shapes/convex_polygon.py
+++ b/coxeter/shapes/convex_polygon.py
@@ -74,8 +74,8 @@ class ConvexPolygon(Polygon):
         ...   square.circumcircle.radius,
         ...   np.sqrt(2.))
         >>> square.gsd_shape_spec
-        {'type': 'Polygon', 'vertices': [[1.0, 1.0, 0.0], [-1.0, 1.0, 0.0],
-        [-1.0, -1.0, 0.0], [1.0, -1.0, 0.0]]}
+        {'type': 'Polygon', 'vertices': [[1.0, 1.0], [-1.0, 1.0],
+        [-1.0, -1.0], [1.0, -1.0]]}
         >>> assert np.isclose(square.maximal_centered_bounded_circle.radius, 1.0)
         >>> assert np.allclose(
         ...   square.inertia_tensor,

--- a/coxeter/shapes/convex_polygon.py
+++ b/coxeter/shapes/convex_polygon.py
@@ -161,6 +161,7 @@ class ConvexPolygon(Polygon):
     @property
     def incircle_from_center(self):
         """:class:`~.Circle`: Get the largest concentric inscribed circle."""
+        self._require_xy_plane()
         warnings.warn(
             "The incircle_from_center property is deprecated, use "
             "maximal_centered_bounded_circle instead.",
@@ -171,6 +172,7 @@ class ConvexPolygon(Polygon):
     @property
     def minimal_centered_bounding_circle(self):
         """:class:`~.Circle`: Get the smallest bounding concentric circle."""
+        self._require_xy_plane()
         # The radius is determined by the furthest vertex from the center.
         return Circle(
             np.linalg.norm(self.vertices - self.center, axis=-1).max(), self.center
@@ -179,6 +181,7 @@ class ConvexPolygon(Polygon):
     @property
     def maximal_centered_bounded_circle(self):
         """:class:`~.Circle`: Get the largest bounded concentric circle."""
+        self._require_xy_plane()
         # The radius is determined by the furthest vertex from the center.
         v1s = self.vertices
         v2s = np.roll(self.vertices, shift=1, axis=0)

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -52,6 +52,18 @@ class ConvexSpheropolygon(Shape2D):
         if not _is_convex(self.vertices, self._polygon.normal):
             raise ValueError("The vertices do not define a convex polygon.")
 
+    def _require_xy_plane(self, allow_negative_z=False):
+        normal = self.normal
+        if allow_negative_z:
+            normal = np.abs(normal)
+        if not np.array_equal(normal, np.array([0, 0, 1])):
+            class_name = type(self).__name__
+            raise ValueError(
+                f"This method requires the {class_name} to be embedded in the xy "
+                "plane with a normal vector pointing along the positive z "
+                f"direction. The normal of this {class_name} is {self.normal}."
+            )
+
     @property
     def polygon(self):
         """:class:`~coxeter.shapes.ConvexPolygon`: The underlying polygon."""

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -29,20 +29,20 @@ class ConvexSpheropolygon(Shape2D):
 
     Example:
         >>> rounded_tri = coxeter.shapes.ConvexSpheropolygon(
-        ...   [[-1, 0], [0, 1], [1, 0]], radius=.1)
+        ...   [[1, 0], [0, 1], [-1, 0]], radius=.1)
         >>> rounded_tri.area
         1.5142...
         >>> rounded_tri.gsd_shape_spec
-        {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]], 'rounding_radius': 0.1}
+        {'type': 'Polygon', 'vertices': [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0]],
+        'rounding_radius': 0.1}
         >>> rounded_tri.radius
         0.1
         >>> rounded_tri.signed_area
         1.5142...
         >>> rounded_tri.vertices
-        array([[-1.,  0.,  0.],
+        array([[ 1.,  0.,  0.],
                [ 0.,  1.,  0.],
-               [ 1.,  0.,  0.]])
+               [-1.,  0.,  0.]])
 
     """
 
@@ -53,7 +53,7 @@ class ConvexSpheropolygon(Shape2D):
             raise ValueError("The vertices do not define a convex polygon.")
 
     def _require_xy_plane(self, allow_negative_z=False):
-        normal = self.normal
+        normal = self.polygon.normal
         if allow_negative_z:
             normal = np.abs(normal)
         if not np.array_equal(normal, np.array([0, 0, 1])):
@@ -61,7 +61,8 @@ class ConvexSpheropolygon(Shape2D):
             raise ValueError(
                 f"This method requires the {class_name} to be embedded in the xy "
                 "plane with a normal vector pointing along the positive z "
-                f"direction. The normal of this {class_name} is {self.normal}."
+                f"direction. The normal of this {class_name} is "
+                f"{self.polygon.normal}."
             )
 
     @property
@@ -72,9 +73,10 @@ class ConvexSpheropolygon(Shape2D):
     @property
     def gsd_shape_spec(self):
         """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
+        self._require_xy_plane()
         return {
             "type": "Polygon",
-            "vertices": self.polygon.vertices.tolist(),
+            "vertices": self.polygon.vertices[:, :2].tolist(),
             "rounding_radius": self.radius,
         }
 

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -156,6 +156,74 @@ class ConvexSpheropolygon(Shape2D):
         else:
             raise ValueError("Perimeter must be greater than zero.")
 
+    def is_inside(self, points):
+        """Determine whether points are contained in this spheropolygon.
+
+        .. note::
+
+            Points on the boundary of the shape will return :code:`True`.
+
+        Args:
+            points (:math:`(N, 3)` :class:`numpy.ndarray`):
+                The points to test. The points must lie in the xy plane.
+
+        Returns:
+            :math:`(N, )` :class:`numpy.ndarray`:
+                Boolean array indicating which points are contained in the
+                spheropolygon.
+
+        Example:
+            >>> rounded_square = coxeter.shapes.ConvexSpheropolygon(
+            ...   [[0, 0], [1, 0], [1, 1], [0, 1]], radius=0.5)
+            >>> rounded_square.is_inside([[0, 0, 0], [1., 1.5, 0], [1.5, 1.5, 0]])
+            array([ True, True, False])
+
+        """
+        self._require_xy_plane()
+        points = np.atleast_2d(points)
+        # For convenience, we support providing points without z components
+        if points.shape[1] == 2:
+            points = np.hstack((points, np.zeros((points.shape[0], 1))))
+        if not np.all(points[:, 2] == 0):
+            raise ValueError(
+                "All provided points must be in the xy plane (points[:, 2] == 0)."
+            )
+
+        # Determine which points are in the polygon
+        in_polygon = self.polygon.is_inside(points)
+
+        # Exit early if all points are inside the convex polygon
+        if np.all(in_polygon):
+            return in_polygon
+
+        def _line_segment_to_point_distance(point, segment_start, segment_end):
+            """Finds minimal distance between a point and a line segment."""
+            start_to_end = segment_end - segment_start
+            start_to_point = point - segment_start
+            end_to_point = point - segment_end
+            past_end = np.dot(start_to_end, end_to_point) > 0
+            if past_end:
+                return np.linalg.norm(end_to_point)
+            past_start = np.dot(start_to_end, start_to_point) < 0
+            if past_start:
+                return np.linalg.norm(start_to_point)
+            perpendicular_distance = np.linalg.norm(
+                np.cross(start_to_end, start_to_point)
+            ) / np.linalg.norm(start_to_end)
+            return perpendicular_distance
+
+        in_sphero_shape = np.zeros(len(points), dtype=bool)
+        for point_index in np.where(~in_polygon)[0]:
+            point = points[point_index]
+            for v_i, v_j in zip(
+                self.vertices, np.roll(self.vertices, shift=-1, axis=0)
+            ):
+                if _line_segment_to_point_distance(point, v_i, v_j) <= self.radius:
+                    in_sphero_shape[point_index] = True
+                    break
+
+        return in_polygon | in_sphero_shape
+
     def __repr__(self):
         return (
             f"coxeter.shapes.ConvexSpheropolygon(vertices={self.vertices.tolist()}, "

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -699,6 +699,7 @@ class Polygon(Shape2D):
                 Boolean array indicating which points are contained in the
                 polyhedron.
         """
+        self._require_xy_plane()
         # Rotate both the vertices and the points into the plane.
         verts, rotation = _align_points_by_normal(self.normal, self.vertices)
         points_in_plane = np.dot(points, rotation.T)

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -96,7 +96,7 @@ class Polygon(Shape2D):
             ``False`` with care.
 
     Example:
-        >>> triangle = coxeter.shapes.Polygon([[-1, 0], [0, 1], [1, 0]])
+        >>> triangle = coxeter.shapes.Polygon([[1, 0], [0, 1], [-1, 0]])
         >>> import numpy as np
         >>> assert np.isclose(triangle.area, 1.0)
         >>> bounding_circle = triangle.minimal_bounding_circle
@@ -105,13 +105,12 @@ class Polygon(Shape2D):
         >>> circumcircle = triangle.circumcircle
         >>> assert np.isclose(circumcircle.radius, 1.0)
         >>> triangle.gsd_shape_spec
-        {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0],
-        [1.0, 0.0, 0.0]]}
+        {'type': 'Polygon', 'vertices': [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0]]}
         >>> assert np.allclose(
         ...   triangle.inertia_tensor,
         ...   np.diag([1. / 9., 0., 1. / 3.]))
         >>> triangle.normal
-        array([ 0., -0., -1.])
+        array([0., 0., 1.])
         >>> assert np.allclose(
         ...   triangle.planar_moments_inertia,
         ...   (1. / 6., 1. / 6., 0.))
@@ -193,7 +192,8 @@ class Polygon(Shape2D):
     @property
     def gsd_shape_spec(self):
         """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
-        return {"type": "Polygon", "vertices": self.vertices.tolist()}
+        self._require_xy_plane()
+        return {"type": "Polygon", "vertices": self.vertices[:, :2].tolist()}
 
     @property
     def normal(self):

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -183,10 +183,11 @@ class Polygon(Shape2D):
         if allow_negative_z:
             normal = np.abs(normal)
         if not np.array_equal(normal, np.array([0, 0, 1])):
+            class_name = type(self).__name__
             raise ValueError(
-                "This method requires the Polygon to be embedded in the xy "
+                f"This method requires the {class_name} to be embedded in the xy "
                 "plane with a normal vector pointing along the positive z "
-                f"direction. The normal of this Polygon is {self.normal}."
+                f"direction. The normal of this {class_name} is {self.normal}."
             )
 
     @property

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -178,6 +178,17 @@ class Polygon(Shape2D):
                     "permitted."
                 )
 
+    def _require_xy_plane(self, allow_negative_z=False):
+        normal = self.normal
+        if allow_negative_z:
+            normal = np.abs(normal)
+        if not np.array_equal(normal, np.array([0, 0, 1])):
+            raise ValueError(
+                "This method requires the Polygon to be embedded in the xy "
+                "plane with a normal vector pointing along the positive z "
+                f"direction. The normal of this Polygon is {self.normal}."
+            )
+
     @property
     def gsd_shape_spec(self):
         """dict: Get a :ref:`complete GSD specification <shapes>`."""  # noqa: D401
@@ -310,6 +321,7 @@ class Polygon(Shape2D):
         rotation used for this computation (i.e. changes in the :math:`x` and
         :math:`y` position) should not be relied upon.
         """  # noqa: E501
+        self._require_xy_plane()
         # Rotate shape so that normal vector coincides with z-axis.
         verts, _ = _align_points_by_normal(self._normal, self._vertices)
 
@@ -440,6 +452,7 @@ class Polygon(Shape2D):
                 If True, vertex indices will be added next to the vertices
                 (Default value: False).
         """
+        self._require_xy_plane()
         ax = _generate_ax(ax)
         verts = self._vertices - self.center if center else self._vertices
         verts, _ = _align_points_by_normal(self._normal, verts)
@@ -459,6 +472,7 @@ class Polygon(Shape2D):
     @property
     def bounding_circle(self):
         """:class:`~.Circle`: Get the minimal bounding circle."""
+        self._require_xy_plane()
         warnings.warn(
             "The bounding_circle property is deprecated, use "
             "minimal_bounding_circle instead",
@@ -470,6 +484,7 @@ class Polygon(Shape2D):
     @property
     def minimal_bounding_circle(self):
         """:class:`~.Circle`: Get the minimal bounding circle."""
+        self._require_xy_plane()
         if not MINIBALL:
             raise ImportError(
                 "The miniball module must be installed. It can "
@@ -517,6 +532,7 @@ class Polygon(Shape2D):
         Raises:
             RuntimeError: If no circumcircle exists for this polygon.
         """
+        self._require_xy_plane()
         # The circumsphere is defined by center C and radius r. For vertex i
         # with position r_i, dot(r_i - C, r_i - C) = r^2, which is equivalent
         # to dot(r_i, r_i) - 2 dot(C, r_i) + dot(C, C) = r^2, a system of
@@ -541,15 +557,17 @@ class Polygon(Shape2D):
     @property
     def circumcircle_radius(self):
         """float: Get the radius of the polygon's circumcircle."""
+        self._require_xy_plane()
         return self.circumcircle.radius
 
     @circumcircle_radius.setter
     def circumcircle_radius(self, value):
+        self._require_xy_plane()
         self._rescale(value / self.circumcircle_radius)
 
     @property
     def incircle(self):
-        """:class:`~.Sphere`: Get the polygon's incircle.
+        """:class:`~.Circle`: Get the polygon's incircle.
 
         Note:
             The incircle of a polygon is defined as the circle contained within
@@ -560,6 +578,7 @@ class Polygon(Shape2D):
             the incircle exists.
 
         """
+        self._require_xy_plane()
         # The incircle is defined by center C and radius r. For face i
         # defined by its unit normal n_i and any point in the plane (choose a
         # vertex v_i for convenience), we must have dot(C + r n_i - v_i, n_i) = 0.
@@ -604,10 +623,12 @@ class Polygon(Shape2D):
     @property
     def incircle_radius(self):
         """float: Get the radius of the polygon's incircle."""
+        self._require_xy_plane()
         return self.incircle.radius
 
     @incircle_radius.setter
     def incircle_radius(self, value):
+        self._require_xy_plane()
         self._rescale(value / self.incircle_radius)
 
     def compute_form_factor_amplitude(self, q, density=1.0):  # noqa: D102

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -686,7 +686,7 @@ class Polygon(Shape2D):
         def _check_inside(p):
             """Check if point is inside, including boundary points.
 
-            The polyhedron check will will raise a ValueError for points on the
+            The polygon check will raise a ValueError for points on the
             boundary, which we want to be inside.
             """
             try:

--- a/coxeter/shapes/polyhedron.py
+++ b/coxeter/shapes/polyhedron.py
@@ -42,13 +42,11 @@ def _face_to_edges(face, reverse=False):
 class Polyhedron(Shape3D):
     """A three-dimensional polytope.
 
-    A polyhedron is defined by a set of vertices and a set of faces
-    composed of the vertices. On construction, the faces are reordered
-    counterclockwise with respect to an outward normal. The polyhedron
-    provides various standard geometric calculations, such as volume and
-    surface area. Most features of the polyhedron can be accessed via
-    properties, including the plane equations defining the faces and the
-    neighbors of each face.
+    A polyhedron is defined by a set of vertices and a set of faces composed
+    of the vertices. The polyhedron provides various standard geometric
+    calculations, such as volume and surface area. Most features of the
+    polyhedron can be accessed via properties, including the plane equations
+    defining the faces and the neighbors of each face.
 
     .. note::
 

--- a/tests/test_shape_getters.py
+++ b/tests/test_shape_getters.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from coxeter import from_gsd_type_shapes
+from coxeter.shapes import Shape2D
 
 
 def test_gsd_shape_getter():
@@ -10,12 +11,12 @@ def test_gsd_shape_getter():
         {"type": "Ellipsoid", "a": 1, "b": 2, "c": 2},
         {
             "type": "Polygon",
-            "vertices": [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0.5, 0.5, 0], [0, 1, 0]],
+            "vertices": [[0, 0], [1, 0], [1, 1], [0.5, 0.5], [0, 1]],
         },
-        {"type": "Polygon", "vertices": [[0, 0, 0], [0, 1, 0], [1, 1, 0], [1, 0, 0]]},
+        {"type": "Polygon", "vertices": [[0, 0], [1, 0], [1, 1], [0, 1]]},
         {
             "type": "Polygon",
-            "vertices": [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]],
+            "vertices": [[0, 0], [1, 0], [1, 1], [0, 1]],
             "rounding_radius": 1,
         },
         {
@@ -79,14 +80,18 @@ def test_gsd_shape_getter():
                 assert shape.radius == value
             elif param != "type":
                 try:
-                    assert getattr(shape, param) == value
+                    if param == "vertices" and isinstance(shape, Shape2D):
+                        check_value = getattr(shape, param)[:, :2]
+                    else:
+                        check_value = getattr(shape, param)
+                    assert check_value == value
                 except ValueError as e:
                     if str(e) == (
                         "The truth value of an array with more than "
                         "one element is ambiguous. Use a.any() or "
                         "a.all()"
                     ):
-                        np.testing.assert_allclose(getattr(shape, param), value)
+                        np.testing.assert_allclose(check_value, value)
 
         # Now convert back and make sure the conversion is lossless.
         assert shape.gsd_shape_spec == shape_spec


### PR DESCRIPTION
## Description
This introduces the private method `_requires_xy_plane()` to Polygon and ConvexSpheropolygon.

I also fixed GSD shape specifications for Polygons and ConvexSpheropolygon so they properly adhere to the spec, which requires vertices to be of shape `(N, 2)`. See: https://gsd.readthedocs.io/en/stable/shapes.html#polygons

To-do:
- [ ] Require 2D shapes to be in-plane, once #132 is merged. ([link 1](https://github.com/glotzerlab/coxeter/pull/132#discussion_r571506288), [link 2](https://github.com/glotzerlab/coxeter/pull/132#discussion_r571506422))

## Motivation and Context
Enforcing this requirement ensures that the shape properties make sense.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).