### PR TITLE
Remove center and bounding/bounded spheres/circles from sphero-shapes.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -12,15 +12,15 @@ Added
 - Point in ellipse checks.
 - Inertia tensors for 2D shapes that implement moments of inertia.
 - Add minimal bounding sphere for all shapes.
-- Add minimal centered bounding sphere calculations for all shapes except general polygons and polyhedra.
+- Add minimal centered bounding sphere calculations for all shapes except general polygons, general polyhedra, spheropolygons, and spheropolyhedra.
 - Enable getting and setting the circumsphere or bounding sphere radius of a polyhedron (for both types of bounding sphere).
 - Add maximal bounded sphere for all shapes.
-- Add maximal centered bounded sphere calculations for all shapes except general polygons and polyhedra.
+- Add maximal centered bounded sphere calculations for all shapes except general polygons, general polyhedra, spheropolygons, and spheropolyhedra.
 - Enable getting and setting the insphere or bounded sphere radius of a polyhedron (for both types of bounding sphere).
 - Point in polygon checks for general (nonconvex) polygons.
 - Point in polyhedron checks for general (nonconvex) polyhedrons.
-- Minimal bounding sphere for all shapes.
-- Minimal centered bounding sphere calculations for all shapes except general polygons and polyhedra.
+- Minimal bounding sphere for all shapes except spheropolygons and spheropolyhedra.
+- Add minimal centered bounding sphere calculations for all shapes except general polygons, general polyhedra, spheropolygons, and spheropolyhedra.
 - Getters and setters for the circumsphere or bounding sphere radius of a polyhedron (for both types of bounding sphere).
 - A repr for all shapes.
 

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -19,6 +19,10 @@ class Shape(ABC):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Alias for :attr:`~.centroid`."""  # noqa: E501
         return self.centroid
 
+    @center.setter
+    def center(self, value):
+        self.centroid = value
+
     @property
     def centroid(self):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -16,6 +16,11 @@ class Shape(ABC):
 
     @property
     def center(self):
+        """:math:`(3, )` :class:`numpy.ndarray` of float: Alias for :attr:`~.centroid`."""  # noqa: E501
+        return self.centroid
+
+    @property
+    def centroid(self):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501
         raise NotImplementedError
 

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -15,10 +15,9 @@ class Shape(ABC):
     """An abstract representation of a shape in N dimensions."""
 
     @property
-    @abstractmethod
     def center(self):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def _rescale(self, scale):

--- a/coxeter/shapes/circle.py
+++ b/coxeter/shapes/circle.py
@@ -12,14 +12,14 @@ class Circle(Shape2D):
         radius (float):
             Radius of the circle.
         center (Sequence[float]):
-            The coordinates of the center of the circle (Default
+            The coordinates of the centroid of the circle (Default
             value: (0, 0, 0)).
 
     Example:
         >>> circle = coxeter.shapes.circle.Circle(radius=1.0, center=(1, 1, 1))
         >>> import numpy as np
         >>> assert np.isclose(circle.area, np.pi)
-        >>> circle.center
+        >>> circle.centroid
         array([1, 1, 1])
         >>> assert np.isclose(circle.circumference, 2 * np.pi)
         >>> circle.eccentricity
@@ -40,7 +40,7 @@ class Circle(Shape2D):
 
     def __init__(self, radius, center=(0, 0, 0)):
         self.radius = radius
-        self.center = center
+        self.centroid = center
 
     @property
     def gsd_shape_spec(self):
@@ -48,13 +48,13 @@ class Circle(Shape2D):
         return {"type": "Sphere", "diameter": 2 * self.radius}
 
     @property
-    def center(self):
+    def centroid(self):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501
-        return self._center
+        return self._centroid
 
-    @center.setter
-    def center(self, value):
-        self._center = np.asarray(value)
+    @centroid.setter
+    def centroid(self, value):
+        self._centroid = np.asarray(value)
 
     @property
     def radius(self):
@@ -146,10 +146,10 @@ class Circle(Shape2D):
         i_x = i_y = area / 4 * self.radius ** 2
         i_xy = 0
 
-        # Apply parallel axis theorem from the center
-        i_x += area * self.center[0] ** 2
-        i_y += area * self.center[1] ** 2
-        i_xy += area * self.center[0] * self.center[1]
+        # Apply parallel axis theorem from the centroid
+        i_x += area * self.centroid[0] ** 2
+        i_y += area * self.centroid[1] ** 2
+        i_xy += area * self.centroid[0] * self.centroid[1]
         return i_x, i_y, i_xy
 
     def is_inside(self, points):
@@ -174,7 +174,7 @@ class Circle(Shape2D):
             array([ True, False])
 
         """
-        points = np.atleast_2d(points) - self.center
+        points = np.atleast_2d(points) - self.centroid
         return np.logical_and(
             np.linalg.norm(points, axis=-1) <= self.radius,
             # At present circles are not orientable, so the z position must
@@ -193,25 +193,25 @@ class Circle(Shape2D):
     @property
     def minimal_bounding_circle(self):
         """:class:`~.Circle`: Get the smallest bounding circle."""
-        return Circle(self.radius, self.center)
+        return Circle(self.radius, self.centroid)
 
     @property
     def minimal_centered_bounding_circle(self):
         """:class:`~.Circle`: Get the smallest bounding concentric circle."""
-        return Circle(self.radius, self.center)
+        return Circle(self.radius, self.centroid)
 
     @property
     def maximal_bounding_circle(self):
         """:class:`~.Circle`: Get the largest bounded circle."""
-        return Circle(self.radius, self.center)
+        return Circle(self.radius, self.centroid)
 
     @property
     def maximal_centered_bounded_circle(self):
         """:class:`~.Circle`: Get the largest bounded concentric circle."""
-        return Circle(self.radius, self.center)
+        return Circle(self.radius, self.centroid)
 
     def __repr__(self):
         return (
             f"coxeter.shapes.Circle(radius={self.radius}, "
-            f"center={self.center.tolist()})"
+            f"center={self.centroid.tolist()})"
         )

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -7,7 +7,6 @@ a circle of some radius.
 import numpy as np
 
 from .base_classes import Shape2D
-from .circle import Circle
 from .convex_polygon import ConvexPolygon, _is_convex
 
 
@@ -33,8 +32,6 @@ class ConvexSpheropolygon(Shape2D):
         ...   [[-1, 0], [0, 1], [1, 0]], radius=.1)
         >>> rounded_tri.area
         1.5142...
-        >>> rounded_tri.center
-        array([0.        , 0.333..., 0.        ])
         >>> rounded_tri.gsd_shape_spec
         {'type': 'Polygon', 'vertices': [[-1.0, 0.0, 0.0],
         [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]], 'rounding_radius': 0.1}
@@ -133,24 +130,6 @@ class ConvexSpheropolygon(Shape2D):
             raise ValueError("Area must be greater than zero.")
 
     @property
-    def center(self):
-        """:math:`(3, )` :class:`numpy.ndarray` of float: Alias for :attr:`~.centroid`."""  # noqa: E501
-        return self.centroid
-
-    @center.setter
-    def center(self, value):
-        self.centroid = value
-
-    @property
-    def centroid(self):
-        """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501
-        return self.polygon.centroid
-
-    @centroid.setter
-    def centroid(self, value):
-        self.polygon.centroid = value
-
-    @property
     def perimeter(self):
         """float: Get the perimeter of the spheropolygon."""
         return self.polygon.perimeter + 2 * np.pi * self.radius
@@ -162,24 +141,6 @@ class ConvexSpheropolygon(Shape2D):
             self._rescale(scale)
         else:
             raise ValueError("Perimeter must be greater than zero.")
-
-    @property
-    def minimal_bounding_circle(self):
-        """:class:`~.Circle`: Get the minimal bounding circle."""
-        polygon_circle = self.polygon.minimal_bounding_circle
-        return Circle(polygon_circle.radius + self.radius, polygon_circle.center)
-
-    @property
-    def minimal_centered_bounding_circle(self):
-        """:class:`~.Circle`: Get the minimal concentric bounding circle."""
-        polygon_circle = self.polygon.minimal_centered_bounding_circle
-        return Circle(polygon_circle.radius + self.radius, polygon_circle.center)
-
-    @property
-    def maximal_centered_bounded_circle(self):
-        """:class:`~.Circle`: Get the maximal concentric bounded circle."""
-        polygon_circle = self.polygon.maximal_centered_bounded_circle
-        return Circle(polygon_circle.radius + self.radius, polygon_circle.center)
 
     def __repr__(self):
         return (

--- a/coxeter/shapes/convex_spheropolyhedron.py
+++ b/coxeter/shapes/convex_spheropolyhedron.py
@@ -4,13 +4,10 @@ A convex spheropolyhedron is defined by the Minkowski sum of a convex
 polyhedron and a sphere of some radius.
 """
 
-import warnings
-
 import numpy as np
 
 from .base_classes import Shape3D
 from .convex_polyhedron import ConvexPolyhedron
-from .sphere import Sphere
 
 
 class ConvexSpheropolyhedron(Shape3D):
@@ -32,18 +29,10 @@ class ConvexSpheropolyhedron(Shape3D):
         ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
         ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]],
         ...   radius=0.5)
-        >>> spherocube.center
-        array([0., 0., 0.])
-        >>> sphere = spherocube.minimal_centered_bounding_sphere
-        >>> sphere.radius
-        2.2320...
         >>> spherocube.gsd_shape_spec
         {'type': 'ConvexPolyhedron', 'vertices': [[1.0, 1.0, 1.0], [1.0, -1.0, 1.0],
         [1.0, 1.0, -1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, 1.0], [-1.0, -1.0, 1.0],
         [-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]], 'rounding_radius': 0.5}
-        >>> sphere = spherocube.maximal_centered_bounded_sphere
-        >>> sphere.radius
-        1.5
         >>> cube = spherocube.polyhedron
         >>> cube.vertices
         array([[ 1.,  1.,  1.],
@@ -94,24 +83,6 @@ class ConvexSpheropolyhedron(Shape3D):
     def vertices(self):
         """Get the vertices of the spheropolyhedron."""
         return self.polyhedron.vertices
-
-    @property
-    def center(self):
-        """:math:`(3, )` :class:`numpy.ndarray` of float: Alias for :attr:`~.centroid`."""  # noqa: E501
-        return self.centroid
-
-    @center.setter
-    def center(self, value):
-        self.centroid = value
-
-    @property
-    def centroid(self):
-        """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501
-        return self.polyhedron.centroid
-
-    @centroid.setter
-    def centroid(self, value):
-        self.polyhedron.centroid = value
 
     def _rescale(self, scale):
         """Multiply length scale.
@@ -314,72 +285,6 @@ class ConvexSpheropolyhedron(Shape3D):
                 in_sphero_shape[point_id] = check_face(point_id, face_id)
 
         return in_polyhedron | in_sphero_shape
-
-    @property
-    def circumsphere_from_center(self):
-        """:class:`~.Sphere`: Get the smallest circumscribed sphere centered at the centroid.
-
-        The requirement that the sphere be centered at the centroid of the
-        shape distinguishes this sphere from most typical circumsphere
-        calculations.
-        """  # noqa: E501
-        warnings.warn(
-            "The circumsphere_from_center property is deprecated, use "
-            "minimal_centered_bounding_sphere instead",
-            DeprecationWarning,
-        )
-        return self.minimal_centered_bounding_sphere
-
-    @property
-    def insphere_from_center(self):
-        """:class:`~.Sphere`: Get the largest inscribed sphere centered at the centroid.
-
-        The requirement that the sphere be centered at the centroid of the
-        shape distinguishes this sphere from most typical insphere
-        calculations.
-
-        """
-        warnings.warn(
-            "The insphere_from_center property is deprecated, use "
-            "maximal_centered_bounded_sphere instead",
-            DeprecationWarning,
-        )
-        return self.maximal_centered_bounded_sphere
-
-    @property
-    def minimal_bounding_sphere(self):
-        """:class:`~.Sphere`: Get the minimal bounding sphere."""
-        polyhedron_sphere = self.polyhedron.minimal_bounding_sphere
-        return Sphere(polyhedron_sphere.radius + self.radius, polyhedron_sphere.center)
-
-    @property
-    def minimal_centered_bounding_sphere(self):
-        """:class:`~.Sphere`: Get the minimal concentric bounding sphere."""
-        polyhedron_sphere = self.polyhedron.minimal_centered_bounding_sphere
-        return Sphere(polyhedron_sphere.radius + self.radius, polyhedron_sphere.center)
-
-    @property
-    def maximal_bounded_sphere(self):
-        """:class:`~.Sphere`: Get the maximal bounded sphere."""
-        polyhedron_sphere = self.polyhedron.maximal_bounded_sphere
-        return Sphere(polyhedron_sphere.radius + self.radius, polyhedron_sphere.center)
-
-    @property
-    def maximal_centered_bounded_sphere(self):
-        """:class:`~.Sphere`: Get the maximal concentric bounded sphere.
-
-        Example:
-            >>> sphero = coxeter.shapes.ConvexSpheropolyhedron(
-            ...   [[1, 1, 1], [1, -1, 1], [1, 1, -1], [1, -1, -1],
-            ...    [-1, 1, 1], [-1, -1, 1], [-1, 1, -1], [-1, -1, -1]],
-            ...   radius=0.5)
-            >>> sphere = sphero.maximal_centered_bounded_sphere
-            >>> import numpy as np
-            >>> assert np.isclose(sphere.radius, 1.5)
-
-        """
-        polyhedron_sphere = self.polyhedron.maximal_centered_bounded_sphere
-        return Sphere(polyhedron_sphere.radius + self.radius, polyhedron_sphere.center)
 
     def __repr__(self):
         return (

--- a/coxeter/shapes/ellipse.py
+++ b/coxeter/shapes/ellipse.py
@@ -17,7 +17,7 @@ class Ellipse(Shape2D):
             Principal axis b of the ellipse (radius in the :math:`y`
             direction).
         center (Sequence[float]):
-            The coordinates of the center of the ellipse (Default
+            The coordinates of the centroid of the ellipse (Default
             value: (0, 0, 0)).
 
     Example:
@@ -28,7 +28,7 @@ class Ellipse(Shape2D):
         2.0
         >>> ellipse.area
         6.28318...
-        >>> ellipse.center
+        >>> ellipse.centroid
         array([0, 0, 0])
         >>> ellipse.circumference
         9.68844...
@@ -48,7 +48,7 @@ class Ellipse(Shape2D):
     def __init__(self, a, b, center=(0, 0, 0)):
         self.a = a
         self.b = b
-        self.center = center
+        self.centroid = center
 
     @property
     def gsd_shape_spec(self):
@@ -56,14 +56,14 @@ class Ellipse(Shape2D):
         return {"type": "Ellipsoid", "a": self.a, "b": self.b}
 
     @property
-    def center(self):
+    def centroid(self):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501
-        return self._center
+        return self._centroid
 
-    @center.setter
-    def center(self, value):
+    @centroid.setter
+    def centroid(self, value):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501
-        self._center = np.asarray(value)
+        self._centroid = np.asarray(value)
 
     @property
     def a(self):
@@ -181,10 +181,10 @@ class Ellipse(Shape2D):
         i_y = area / 4 * self.a ** 2
         i_xy = 0
 
-        # Apply parallel axis theorem from the center
-        i_x += area * self.center[0] ** 2
-        i_y += area * self.center[1] ** 2
-        i_xy += area * self.center[0] * self.center[1]
+        # Apply parallel axis theorem from the centroid
+        i_x += area * self.centroid[0] ** 2
+        i_y += area * self.centroid[1] ** 2
+        i_xy += area * self.centroid[0] * self.centroid[1]
         return i_x, i_y, i_xy
 
     @property
@@ -195,22 +195,22 @@ class Ellipse(Shape2D):
     @property
     def minimal_centered_bounding_circle(self):
         """:class:`~.Circle`: Get the smallest bounding concentric circle."""
-        return Circle(max(self.a, self.b), self.center)
+        return Circle(max(self.a, self.b), self.centroid)
 
     @property
     def minimal_bounding_circle(self):
         """:class:`~.Circle`: Get the smallest bounding circle."""
-        return Circle(max(self.a, self.b), self.center)
+        return Circle(max(self.a, self.b), self.centroid)
 
     @property
     def maximal_centered_bounded_circle(self):
         """:class:`~.Circle`: Get the largest bounded concentric circle."""
-        return Circle(min(self.a, self.b), self.center)
+        return Circle(min(self.a, self.b), self.centroid)
 
     @property
     def maximal_bounded_circle(self):
         """:class:`~.Circle`: Get the largest bounded circle."""
-        return Circle(min(self.a, self.b), self.center)
+        return Circle(min(self.a, self.b), self.centroid)
 
     def is_inside(self, points):
         """Determine whether a set of points are contained in this ellipse.
@@ -234,7 +234,7 @@ class Ellipse(Shape2D):
             array([ True, False])
 
         """
-        points = np.atleast_2d(points) - self.center
+        points = np.atleast_2d(points) - self.centroid
         scale = np.array([self.a, self.b, np.inf])
         return np.logical_and(
             np.all(points / scale <= 1, axis=-1),
@@ -246,5 +246,5 @@ class Ellipse(Shape2D):
     def __repr__(self):
         return (
             f"coxeter.shapes.Ellipse(a={self.a}, b={self.b}, "
-            f"center={self.center.tolist()})"
+            f"center={self.centroid.tolist()})"
         )

--- a/coxeter/shapes/ellipsoid.py
+++ b/coxeter/shapes/ellipsoid.py
@@ -22,7 +22,7 @@ class Ellipsoid(Shape3D):
             Length of the principal semi-axis of the ellipsoid in the :math:`z`
             direction.
         center (Sequence[float]):
-            The coordinates of the center of the ellipsoid (Default
+            The coordinates of the centroid of the ellipsoid (Default
             value: (0, 0, 0)).
 
     Example:
@@ -33,7 +33,7 @@ class Ellipsoid(Shape3D):
         3.0
         >>> ellipsoid.c
         2.0
-        >>> ellipsoid.center
+        >>> ellipsoid.centroid
         array([0, 0, 0])
         >>> ellipsoid.gsd_shape_spec
         {'type': 'Ellipsoid', 'a': 1.0, 'b': 3.0, 'c': 2.0}
@@ -54,7 +54,7 @@ class Ellipsoid(Shape3D):
         self.a = a
         self.b = b
         self.c = c
-        self.center = center
+        self.centroid = center
 
     @property
     def gsd_shape_spec(self):
@@ -62,13 +62,13 @@ class Ellipsoid(Shape3D):
         return {"type": "Ellipsoid", "a": self.a, "b": self.b, "c": self.c}
 
     @property
-    def center(self):
+    def centroid(self):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501
-        return self._center
+        return self._centroid
 
-    @center.setter
-    def center(self, value):
-        self._center = np.asarray(value)
+    @centroid.setter
+    def centroid(self, value):
+        self._centroid = np.asarray(value)
 
     @property
     def a(self):
@@ -168,7 +168,7 @@ class Ellipsoid(Shape3D):
         i_yy = vol / 5 * (self.a ** 2 + self.c ** 2)
         i_zz = vol / 5 * (self.a ** 2 + self.b ** 2)
         inertia_tensor = np.diag([i_xx, i_yy, i_zz])
-        return translate_inertia_tensor(self.center, inertia_tensor, vol)
+        return translate_inertia_tensor(self.centroid, inertia_tensor, vol)
 
     def is_inside(self, points):
         """Determine whether a set of points are contained in this ellipsoid.
@@ -192,32 +192,32 @@ class Ellipsoid(Shape3D):
             array([ True, False])
 
         """
-        points = np.atleast_2d(points) - self.center
+        points = np.atleast_2d(points) - self.centroid
         scale = np.array([self.a, self.b, self.c])
         return np.linalg.norm(points / scale, axis=-1) <= 1
 
     @property
     def minimal_centered_bounding_sphere(self):
         """:class:`~.Sphere`: Get the smallest bounding concentric sphere."""
-        return Sphere(max(self.a, self.b, self.c), self.center)
+        return Sphere(max(self.a, self.b, self.c), self.centroid)
 
     @property
     def minimal_bounding_sphere(self):
         """:class:`~.Sphere`: Get the smallest bounding sphere."""
-        return Sphere(max(self.a, self.b, self.c), self.center)
+        return Sphere(max(self.a, self.b, self.c), self.centroid)
 
     @property
     def maximal_centered_bounded_sphere(self):
         """:class:`~.Sphere`: Get the largest bounded concentric sphere."""
-        return Sphere(min(self.a, self.b, self.c), self.center)
+        return Sphere(min(self.a, self.b, self.c), self.centroid)
 
     @property
     def maximal_bounded_sphere(self):
         """:class:`~.Sphere`: Get the largest bounded sphere."""
-        return Sphere(min(self.a, self.b, self.c), self.center)
+        return Sphere(min(self.a, self.b, self.c), self.centroid)
 
     def __repr__(self):
         return (
             f"coxeter.shapes.Ellipsoid(a={self.a}, b={self.b}, c={self.c}, "
-            f"center={self.center.tolist()})"
+            f"center={self.centroid.tolist()})"
         )

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -379,15 +379,6 @@ class Polygon(Shape2D):
         return shifted_inertia_tensor
 
     @property
-    def center(self):
-        """:math:`(3, )` :class:`numpy.ndarray` of float: Alias for :attr:`~.centroid`."""  # noqa: E501
-        return self.centroid
-
-    @center.setter
-    def center(self, value):
-        self.centroid = value
-
-    @property
     def centroid(self):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape.
 

--- a/coxeter/shapes/polyhedron.py
+++ b/coxeter/shapes/polyhedron.py
@@ -490,15 +490,6 @@ class Polyhedron(Shape3D):
         return np.array([[i_xx, i_xy, i_xz], [i_xy, i_yy, i_yz], [i_xz, i_yz, i_zz]])
 
     @property
-    def center(self):
-        """:math:`(3, )` :class:`numpy.ndarray` of float: Alias for :attr:`~.centroid`."""  # noqa: E501
-        return self.centroid
-
-    @center.setter
-    def center(self, value):
-        self.centroid = value
-
-    @property
     def centroid(self):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape.
 

--- a/coxeter/shapes/sphere.py
+++ b/coxeter/shapes/sphere.py
@@ -13,13 +13,13 @@ class Sphere(Shape3D):
         radius (float):
             Radius of the sphere.
         center (Sequence[float]):
-            The coordinates of the center of the sphere (Default
+            The coordinates of the centroid of the sphere (Default
             value: (0, 0, 0)).
 
     Example:
         >>> sphere = coxeter.shapes.Sphere(1.0)
         >>> assert np.isclose(sphere.radius, 1.0)
-        >>> assert np.allclose(sphere.center, [0., 0., 0.])
+        >>> assert np.allclose(sphere.centroid, [0., 0., 0.])
         >>> sphere.gsd_shape_spec
         {'type': 'Sphere', 'diameter': 2.0}
         >>> assert np.allclose(
@@ -36,7 +36,7 @@ class Sphere(Shape3D):
 
     def __init__(self, radius, center=(0, 0, 0)):
         self.radius = radius
-        self.center = center
+        self.centroid = center
 
     @property
     def gsd_shape_spec(self):
@@ -44,14 +44,14 @@ class Sphere(Shape3D):
         return {"type": "Sphere", "diameter": 2 * self.radius}
 
     @property
-    def center(self):
+    def centroid(self):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501
-        return self._center
+        return self._centroid
 
-    @center.setter
-    def center(self, value):
+    @centroid.setter
+    def centroid(self, value):
         """:math:`(3, )` :class:`numpy.ndarray` of float: Get or set the centroid of the shape."""  # noqa: E501
-        self._center = np.asarray(value)
+        self._centroid = np.asarray(value)
 
     @property
     def radius(self):
@@ -107,7 +107,7 @@ class Sphere(Shape3D):
         vol = self.volume
         i_xx = vol * 2 / 5 * self.radius ** 2
         inertia_tensor = np.diag([i_xx, i_xx, i_xx])
-        return translate_inertia_tensor(self.center, inertia_tensor, vol)
+        return translate_inertia_tensor(self.centroid, inertia_tensor, vol)
 
     @property
     def iq(self):
@@ -139,7 +139,7 @@ class Sphere(Shape3D):
             array([ True, False])
 
         """
-        points = np.atleast_2d(points) - self.center
+        points = np.atleast_2d(points) - self.centroid
         return np.linalg.norm(points, axis=-1) <= self.radius
 
     def compute_form_factor_amplitude(self, q, density=1.0):  # noqa: D102
@@ -163,31 +163,31 @@ class Sphere(Shape3D):
         ) / q_sqs[~zero_q]
 
         # Shift the form factor to the particle's position and scale by density.
-        form_factor *= density * np.exp(-1j * np.dot(q, self.center))
+        form_factor *= density * np.exp(-1j * np.dot(q, self.centroid))
         return form_factor
 
     @property
     def minimal_centered_bounding_sphere(self):
         """:class:`~.Sphere`: Get the smallest bounding concentric sphere."""
-        return Sphere(self.radius, self.center)
+        return Sphere(self.radius, self.centroid)
 
     @property
     def minimal_bounding_sphere(self):
         """:class:`~.Sphere`: Get the smallest bounding sphere."""
-        return Sphere(self.radius, self.center)
+        return Sphere(self.radius, self.centroid)
 
     @property
     def maximal_centered_bounded_sphere(self):
         """:class:`~.Sphere`: Get the largest bounded concentric sphere."""
-        return Sphere(self.radius, self.center)
+        return Sphere(self.radius, self.centroid)
 
     @property
     def maximal_bounded_sphere(self):
         """:class:`~.Sphere`: Get the largest bounded sphere."""
-        return Sphere(self.radius, self.center)
+        return Sphere(self.radius, self.centroid)
 
     def __repr__(self):
         return (
             f"coxeter.shapes.Sphere(radius={self.radius}, "
-            f"center={self.center.tolist()})"
+            f"center={self.centroid.tolist()})"
         )

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -7,11 +7,7 @@ from hypothesis.strategies import floats
 from pytest import approx
 from scipy.spatial import ConvexHull
 
-from conftest import (
-    EllipseSurfaceStrategy,
-    _test_get_set_minimal_bounding_sphere_radius,
-)
-from coxeter.families import RegularNGonFamily
+from conftest import EllipseSurfaceStrategy
 from coxeter.shapes import ConvexSpheropolygon
 
 
@@ -118,14 +114,6 @@ def test_area_getter_setter(unit_rounded_square):
     testfun()
 
 
-def test_center(square_points, unit_rounded_square):
-    """Test centering the polygon."""
-    square = unit_rounded_square
-    assert np.all(square.center == np.mean(square_points, axis=0))
-    square.center = [0, 0, 0]
-    assert np.all(square.center == [0, 0, 0])
-
-
 def test_nonplanar(square_points):
     """Ensure that nonplanar vertices raise an error."""
     with pytest.raises(ValueError):
@@ -195,43 +183,6 @@ def test_perimeter_setter(unit_rounded_square):
         assert unit_rounded_square.radius == approx(1.0)
 
     testfun()
-
-
-@given(floats(0.1, 1000))
-def test_minimal_bounding_circle_regular_polygon(radius):
-    family = RegularNGonFamily()
-    for i in range(3, 10):
-        vertices = family.make_vertices(i)
-        rmax = np.max(np.linalg.norm(vertices, axis=-1)) + radius
-
-        poly = ConvexSpheropolygon(vertices, radius)
-        circle = poly.minimal_bounding_circle
-
-        assert np.isclose(rmax, circle.radius)
-        assert np.allclose(circle.center, 0)
-
-
-@given(floats(0.1, 1000))
-def test_minimal_centered_bounding_circle_regular_polygon(radius):
-    family = RegularNGonFamily()
-    for i in range(3, 10):
-        vertices = family.make_vertices(i)
-        rmax = np.max(np.linalg.norm(vertices, axis=-1)) + radius
-
-        poly = ConvexSpheropolygon(vertices, radius)
-        circle = poly.minimal_centered_bounding_circle
-
-        assert np.isclose(rmax, circle.radius)
-        assert np.allclose(circle.center, 0)
-
-
-@given(floats(0.1, 1000))
-def test_get_set_minimal_bounding_circle_radius(r):
-    family = RegularNGonFamily()
-    for i in range(3, 10):
-        _test_get_set_minimal_bounding_sphere_radius(
-            ConvexSpheropolygon(family.make_vertices(i), r)
-        )
 
 
 def test_inertia(unit_rounded_square):


### PR DESCRIPTION
## Description
Removes `center`, `centroid`, and bounding circles/spheres from the spheropolygon and spheropolyhedron classes. The implementation of `centroid` was not valid for arbitrary sphero-shapes.

## Motivation and Context
If it ain't broke, don't fix it. If it is broke, delete it before shipping. `#cantfixwontfix`

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
