### PR TITLE
Build only htmlzip docs.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,6 @@
 version: 2
-formats: all
+formats:
+    - htmlzip
 conda:
     environment: doc/environment.yml
 python:


### PR DESCRIPTION
## Description
Removes LaTeX documentation formats to fix the build error shown here: https://readthedocs.org/projects/coxeter/builds/14275171/

```
Running Sphinx v4.1.1
loading translations [en]... done
making output directory... done
loading pickled environment... checking for /home/docs/checkouts/readthedocs.org/user_builds/coxeter/checkouts/latest/doc/source/coxeter.bib in bibtex cache... up to date
done
[autosummary] generating autosummary for: changelog.rst, coxeter.rst, credits.rst, development.rst, examples.rst, examples/DistanceToSurface.ipynb, examples/FormFactors.ipynb, examples/InertiaTensors.ipynb, examples/PointInShape.ipynb, examples/Spheres.ipynb, index.rst, license.rst, module-shape-getters.rst, package-families.rst, package-shapes.rst, quickstart.rst, zreferences.rst
building [mo]: targets for 0 po files that are out of date
building [latex]: all documents
updating environment: 0 added, 0 changed, 0 removed
looking for now-outdated files... none found
processing coxeter.tex... index quickstart coxeter package-shapes package-families module-shape-getters examples examples/PointInShape examples/DistanceToSurface examples/InertiaTensors examples/Spheres examples/FormFactors development changelog credits license zreferences 
resolving references...
../../README.rst:: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://joss.theoj.org/papers/10.21105/joss.03098/status.svg)
../../README.rst:: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://readthedocs.org/projects/coxeter/badge/?version=latest)
../../README.rst:: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://circleci.com/gh/glotzerlab/coxeter.svg?style=svg)
../../README.rst:: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://img.shields.io/pypi/v/coxeter.svg)
../../README.rst:: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://img.shields.io/conda/vn/conda-forge/coxeter.svg)
done
writing... failed

Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/coxeter/conda/latest/lib/python3.9/site-packages/nbsphinx.py", line 2151, in depart_codearea_latex
    assert 'Verbatim' in lines[0]
AssertionError
The full traceback has been saved in /tmp/sphinx-err-i11l9q4t.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```

## Motivation and Context
Docs are broken. This build fixes it (see RTD check below).

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [x] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
