### PR TITLE
Fix numerical precision in tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: isort
         exclude: '(?:extern/.*)'
   - repo: https://github.com/psf/black
-    rev: '20.8b1'
+    rev: '22.1.0'
     hooks:
       - id: black
         exclude: '(?:extern/.*)'

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,15 @@
 The format is based on `Keep a Changelog <http://keepachangelog.com/en/1.0.0/>`__.
 This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`__.
 
+v0.6.2 - 202x-xx-xx
+-------------------
+
+Fixed
+~~~~~
+
+- Numerical precision issues in tests.
+
+
 v0.6.1 - 2021-07-15
 -------------------
 
@@ -8,7 +17,6 @@ Fixed
 ~~~~~
 
 - Typos in JOSS paper.
-- Numerical precision issues in tests.
 
 v0.6.0 - 2021-07-14
 -------------------

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -8,6 +8,7 @@ Fixed
 ~~~~~
 
 - Typos in JOSS paper.
+- Numerical precision issues in tests.
 
 v0.6.0 - 2021-07-14
 -------------------

--- a/coxeter/families/plane_shape_families.py
+++ b/coxeter/families/plane_shape_families.py
@@ -310,18 +310,18 @@ class Family523(TruncationPlaneShapeFamily):
             [-S, -S, S],
             [-S, S, -S],
             [-S, -S, -S],
-            [1.0, 0.0, S ** 2],
-            [-1.0, 0.0, -(S ** 2)],
-            [-1.0, 0.0, S ** 2],
-            [1.0, 0.0, -(S ** 2)],
-            [0.0, -(S ** 2), -1.0],
-            [0.0, S ** 2, 1.0],
-            [0.0, -(S ** 2), 1.0],
-            [0.0, S ** 2, -1.0],
-            [-(S ** 2), -1.0, 0.0],
-            [S ** 2, 1.0, 0.0],
-            [S ** 2, -1.0, 0.0],
-            [-(S ** 2), 1.0, 0.0],
+            [1.0, 0.0, S**2],
+            [-1.0, 0.0, -(S**2)],
+            [-1.0, 0.0, S**2],
+            [1.0, 0.0, -(S**2)],
+            [0.0, -(S**2), -1.0],
+            [0.0, S**2, 1.0],
+            [0.0, -(S**2), 1.0],
+            [0.0, S**2, -1.0],
+            [-(S**2), -1.0, 0.0],
+            [S**2, 1.0, 0.0],
+            [S**2, -1.0, 0.0],
+            [-(S**2), 1.0, 0.0],
             [S, -1.0, -s],
             [-S, 1.0, -s],
             [-S, -1.0, s],
@@ -435,7 +435,7 @@ class Family523(TruncationPlaneShapeFamily):
                 "The a parameter must be between 1 and s\u221A5 "
                 "(where s is the inverse of the golden ratio)."
             )
-        if not cls.S ** 2 <= c <= 3:
+        if not cls.S**2 <= c <= 3:
             raise ValueError(
                 "The c parameter must be between S^2 and 3 "
                 "(where S is the golden ratio)."

--- a/coxeter/shapes/base_classes.py
+++ b/coxeter/shapes/base_classes.py
@@ -264,7 +264,7 @@ class Shape2D(Shape):
                    &= \frac{4\pi A}{p^2}
             \end{align}
         """  # noqa: E501
-        return 4 * np.pi * self.area / (self.perimeter ** 2)
+        return 4 * np.pi * self.area / (self.perimeter**2)
 
     @property
     def minimal_bounding_circle(self):
@@ -416,7 +416,7 @@ class Shape3D(Shape):
                    &= \frac{36\pi V^2}{S^3}
             \end{align}
         """  # noqa: E501
-        return np.pi * 36 * self.volume ** 2 / (self.surface_area ** 3)
+        return np.pi * 36 * self.volume**2 / (self.surface_area**3)
 
     @property
     def minimal_bounding_sphere(self):

--- a/coxeter/shapes/circle.py
+++ b/coxeter/shapes/circle.py
@@ -83,7 +83,7 @@ class Circle(Shape2D):
     @property
     def area(self):
         """float: Get the area of the circle."""
-        return np.pi * self.radius ** 2
+        return np.pi * self.radius**2
 
     @area.setter
     def area(self, value):
@@ -146,7 +146,7 @@ class Circle(Shape2D):
         that the product moment is zero by symmetry.
         """  # noqa: E501
         area = self.area
-        i_x = i_y = area / 4 * self.radius ** 2
+        i_x = i_y = area / 4 * self.radius**2
         i_xy = 0
 
         # Apply parallel axis theorem from the centroid

--- a/coxeter/shapes/convex_spheropolygon.py
+++ b/coxeter/shapes/convex_spheropolygon.py
@@ -245,8 +245,8 @@ class ConvexSpheropolygon(Shape2D):
                 phi += 2 * np.pi
             a = 1
             b = -2 * norm_v * np.cos(angles[indices] - phi)
-            c = norm_v ** 2 - self.radius ** 2
-            kernel[indices] = (-b + np.sqrt(b ** 2 - 4 * a * c)) / (2 * a)
+            c = norm_v**2 - self.radius**2
+            kernel[indices] = (-b + np.sqrt(b**2 - 4 * a * c)) / (2 * a)
 
         return kernel
 

--- a/coxeter/shapes/convex_spheropolyhedron.py
+++ b/coxeter/shapes/convex_spheropolyhedron.py
@@ -111,7 +111,7 @@ class ConvexSpheropolyhedron(Shape3D):
         # 4) The volume of the extruded faces, which is the surface area of
         #    each face multiplied by the rounding radius.
         v_poly = self.polyhedron.volume
-        v_sphere = (4 / 3) * np.pi * self.radius ** 3
+        v_sphere = (4 / 3) * np.pi * self.radius**3
         v_cyl = 0
         v_face = self.polyhedron.surface_area * self.radius
 
@@ -123,7 +123,7 @@ class ConvexSpheropolyhedron(Shape3D):
             edge_length = np.linalg.norm(
                 self.polyhedron.vertices[edge[0]] - self.polyhedron.vertices[edge[1]]
             )
-            v_cyl += (np.pi * self.radius ** 2) * (phi / (2 * np.pi)) * edge_length
+            v_cyl += (np.pi * self.radius**2) * (phi / (2 * np.pi)) * edge_length
 
         return v_poly + v_sphere + v_face + v_cyl
 
@@ -156,7 +156,7 @@ class ConvexSpheropolyhedron(Shape3D):
         #    angle of the face to determine what fraction of the cylinder to
         #    include.
         a_poly = self.polyhedron.surface_area
-        a_sphere = 4 * np.pi * self.radius ** 2
+        a_sphere = 4 * np.pi * self.radius**2
         a_cyl = 0
 
         # For every pair of faces, find the dihedral angle, divide by 2*pi to

--- a/coxeter/shapes/ellipse.py
+++ b/coxeter/shapes/ellipse.py
@@ -125,7 +125,7 @@ class Ellipse(Shape2D):
         """
         # Requires that a >= b, so we sort the principal axes:
         b, a = sorted([self.a, self.b])
-        e = np.sqrt(1 - b ** 2 / a ** 2)
+        e = np.sqrt(1 - b**2 / a**2)
         return e
 
     @property
@@ -135,7 +135,7 @@ class Ellipse(Shape2D):
         # https://scipython.com/book/chapter-8-scipy/examples/the-circumference-of-an-ellipse/
         # It requires that a >= b, so we sort the principal axes:
         b, a = sorted([self.a, self.b])
-        result = 4 * a * ellipe(self.eccentricity ** 2)
+        result = 4 * a * ellipe(self.eccentricity**2)
         return result
 
     @perimeter.setter
@@ -180,8 +180,8 @@ class Ellipse(Shape2D):
         that the product moment is zero by symmetry.
         """  # noqa: E501
         area = self.area
-        i_x = area / 4 * self.b ** 2
-        i_y = area / 4 * self.a ** 2
+        i_x = area / 4 * self.b**2
+        i_y = area / 4 * self.a**2
         i_xy = 0
 
         # Apply parallel axis theorem from the centroid
@@ -209,7 +209,7 @@ class Ellipse(Shape2D):
     @property
     def iq(self):
         """float: The isoperimetric quotient."""
-        return np.min([4 * np.pi * self.area / (self.perimeter ** 2), 1])
+        return np.min([4 * np.pi * self.area / (self.perimeter**2), 1])
 
     @property
     def minimal_centered_bounding_circle(self):

--- a/coxeter/shapes/ellipsoid.py
+++ b/coxeter/shapes/ellipsoid.py
@@ -142,14 +142,14 @@ class Ellipsoid(Shape3D):
         c, b, a = sorted([self.a, self.b, self.c])
         if a > c:
             phi = np.arccos(c / a)
-            m = (a ** 2 * (b ** 2 - c ** 2)) / (b ** 2 * (a ** 2 - c ** 2))
+            m = (a**2 * (b**2 - c**2)) / (b**2 * (a**2 - c**2))
             elliptic_part = ellipeinc(phi, m) * np.sin(phi) ** 2
             elliptic_part += ellipkinc(phi, m) * np.cos(phi) ** 2
             elliptic_part /= np.sin(phi)
         else:
             elliptic_part = 1
 
-        result = 2 * np.pi * (c ** 2 + a * b * elliptic_part)
+        result = 2 * np.pi * (c**2 + a * b * elliptic_part)
         return result
 
     @surface_area.setter
@@ -167,9 +167,9 @@ class Ellipsoid(Shape3D):
         Assumes a constant density of 1.
         """
         vol = self.volume
-        i_xx = vol / 5 * (self.b ** 2 + self.c ** 2)
-        i_yy = vol / 5 * (self.a ** 2 + self.c ** 2)
-        i_zz = vol / 5 * (self.a ** 2 + self.b ** 2)
+        i_xx = vol / 5 * (self.b**2 + self.c**2)
+        i_yy = vol / 5 * (self.a**2 + self.c**2)
+        i_zz = vol / 5 * (self.a**2 + self.b**2)
         inertia_tensor = np.diag([i_xx, i_yy, i_zz])
         return translate_inertia_tensor(self.centroid, inertia_tensor, vol)
 

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -326,8 +326,8 @@ class Polygon(Shape2D):
         # These are the terms in the formulas for Ix and Iy, which are computed
         # simulataneously since they're identical except that they use either
         # the x or y coordinates.
-        sv_sq = shifted_verts ** 2
-        verts_sq = verts ** 2
+        sv_sq = shifted_verts**2
+        verts_sq = verts**2
         prod = verts * shifted_verts
 
         # This accounts for the x_i*y_{i+1} and x_{i+1}*y_i terms in Ixy.

--- a/coxeter/shapes/sphere.py
+++ b/coxeter/shapes/sphere.py
@@ -80,7 +80,7 @@ class Sphere(Shape3D):
     @property
     def volume(self):
         """float: Get the volume of the sphere."""
-        return (4 / 3) * np.pi * self.radius ** 3
+        return (4 / 3) * np.pi * self.radius**3
 
     @volume.setter
     def volume(self, value):
@@ -92,7 +92,7 @@ class Sphere(Shape3D):
     @property
     def surface_area(self):
         """float: Get the surface area."""
-        return 4 * np.pi * self.radius ** 2
+        return 4 * np.pi * self.radius**2
 
     @surface_area.setter
     def surface_area(self, value):
@@ -108,7 +108,7 @@ class Sphere(Shape3D):
         Assumes a constant density of 1.
         """
         vol = self.volume
-        i_xx = vol * 2 / 5 * self.radius ** 2
+        i_xx = vol * 2 / 5 * self.radius**2
         inertia_tensor = np.diag([i_xx, i_xx, i_xx])
         return translate_inertia_tensor(self.centroid, inertia_tensor, vol)
 

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -61,7 +61,7 @@ def test_set_area(area):
 @given(floats(0.1, 1000))
 def test_iq(r):
     circle = Circle(r)
-    assert circle.iq == approx(1)
+    assert circle.iq == 1
 
 
 @given(floats(0.1, 1000))
@@ -193,7 +193,7 @@ def test_inertia_tensor():
     """Test the inertia tensor calculation."""
     circle = Circle(1)
     circle.center = (0, 0, 0)
-    assert np.sum(circle.inertia_tensor > 1e-6) == approx(1)
+    assert np.sum(circle.inertia_tensor > 1e-6) == 1
     assert circle.inertia_tensor[2, 2] == approx(np.pi / 2)
 
 

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -20,8 +20,8 @@ from coxeter.shapes import Circle
 def test_perimeter(r):
     circle = Circle(1)
     circle.radius = r
-    assert circle.perimeter == 2 * np.pi * r
-    assert circle.circumference == 2 * np.pi * r
+    assert circle.perimeter == approx(2 * np.pi * r)
+    assert circle.circumference == approx(2 * np.pi * r)
 
 
 @given(floats(0.1, 1000))
@@ -29,16 +29,16 @@ def test_perimeter_setter(perimeter):
     """Test setting the perimeter."""
     circle = Circle(1)
     circle.perimeter = perimeter
-    assert circle.radius == perimeter / (2 * np.pi)
+    assert circle.radius == approx(perimeter / (2 * np.pi))
     assert circle.perimeter == approx(perimeter)
     circle.perimeter = perimeter + 1
-    assert circle.radius == (perimeter + 1) / (2 * np.pi)
+    assert circle.radius == approx((perimeter + 1) / (2 * np.pi))
     assert circle.perimeter == approx(perimeter + 1)
     circle.circumference = perimeter
-    assert circle.radius == perimeter / (2 * np.pi)
+    assert circle.radius == approx(perimeter / (2 * np.pi))
     assert circle.circumference == approx(perimeter)
     circle.circumference = perimeter + 1
-    assert circle.radius == (perimeter + 1) / (2 * np.pi)
+    assert circle.radius == approx((perimeter + 1) / (2 * np.pi))
     assert circle.circumference == approx(perimeter + 1)
 
 
@@ -46,7 +46,7 @@ def test_perimeter_setter(perimeter):
 def test_area(r):
     circle = Circle(1)
     circle.radius = r
-    assert circle.area == np.pi * r ** 2
+    assert circle.area == approx(np.pi * r ** 2)
 
 
 @given(floats(0.1, 1000))
@@ -61,7 +61,7 @@ def test_set_area(area):
 @given(floats(0.1, 1000))
 def test_iq(r):
     circle = Circle(r)
-    assert circle.iq == 1
+    assert circle.iq == approx(1)
 
 
 @given(floats(0.1, 1000))
@@ -92,20 +92,20 @@ def test_moment_inertia(r, center):
 def test_center():
     """Test getting and setting the center."""
     circle = Circle(1)
-    assert all(circle.center == (0, 0, 0))
+    np.testing.assert_allclose(circle.center, (0, 0, 0))
 
     center = (1, 1, 1)
     circle.center = center
-    assert all(circle.center == center)
+    np.testing.assert_allclose(circle.center, center)
 
 
 @given(floats(0.1, 1000))
 def test_radius_getter_setter(r):
     """Test getting and setting the radius."""
     circle = Circle(r)
-    assert circle.radius == r
+    assert circle.radius == approx(r)
     circle.radius = r + 1
-    assert circle.radius == r + 1
+    assert circle.radius == approx(r + 1)
 
 
 def test_invalid_radius():
@@ -193,8 +193,8 @@ def test_inertia_tensor():
     """Test the inertia tensor calculation."""
     circle = Circle(1)
     circle.center = (0, 0, 0)
-    assert np.sum(circle.inertia_tensor > 1e-6) == 1
-    assert circle.inertia_tensor[2, 2] == np.pi / 2
+    assert np.sum(circle.inertia_tensor > 1e-6) == approx(1)
+    assert circle.inertia_tensor[2, 2] == approx(np.pi / 2)
 
 
 def test_repr():

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -46,7 +46,7 @@ def test_perimeter_setter(perimeter):
 def test_area(r):
     circle = Circle(1)
     circle.radius = r
-    assert circle.area == approx(np.pi * r ** 2)
+    assert circle.area == approx(np.pi * r**2)
 
 
 @given(floats(0.1, 1000))
@@ -79,8 +79,8 @@ def test_moment_inertia(r, center):
     assert np.all(np.asarray(circle.planar_moments_inertia) >= 0)
 
     circle.center = center
-    area = np.pi * r ** 2
-    expected = [np.pi / 4 * r ** 4] * 3
+    area = np.pi * r**2
+    expected = [np.pi / 4 * r**4] * 3
     expected[0] += area * center[0] ** 2
     expected[1] += area * center[1] ** 2
     expected[2] = area * center[0] * center[1]

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -231,7 +231,7 @@ def test_inertia_tensor():
     """Test the inertia tensor calculation."""
     ellipse = Ellipse(1, 2)
     ellipse.center = (0, 0, 0)
-    assert np.sum(ellipse.inertia_tensor > 1e-6) == approx(1)
+    assert np.sum(ellipse.inertia_tensor > 1e-6) == 1
     assert ellipse.inertia_tensor[2, 2] == approx(5 * np.pi / 2)
 
 

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -24,8 +24,8 @@ def test_a_b_getter_setter(a, b):
     assert ellipse.b == b
     ellipse.a = a + 1
     ellipse.b = b + 1
-    assert ellipse.a == a + 1
-    assert ellipse.b == b + 1
+    assert ellipse.a == approx(a + 1)
+    assert ellipse.b == approx(b + 1)
 
 
 @given(floats(-1000, -1))
@@ -58,8 +58,8 @@ def test_perimeter(a, b):
     b, a = sorted([a, b])
     h = (a - b) ** 2 / (a + b) ** 2
     approx_perimeter = np.pi * (a + b) * (1 + 3 * h / (10 + np.sqrt(4 - 3 * h)))
-    assert ellipse.perimeter == pytest.approx(approx_perimeter, rel=1e-3)
-    assert ellipse.circumference == pytest.approx(approx_perimeter, rel=1e-3)
+    assert ellipse.perimeter == approx(approx_perimeter, rel=1e-3)
+    assert ellipse.circumference == approx(approx_perimeter, rel=1e-3)
 
 
 @given(floats(0.1, 1000))
@@ -84,7 +84,7 @@ def test_area_getter(a, b):
     ellipse = Ellipse(1, 1)
     ellipse.a = a
     ellipse.b = b
-    assert ellipse.area == np.pi * a * b
+    assert ellipse.area == approx(np.pi * a * b)
 
 
 @given(floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000))
@@ -120,7 +120,7 @@ def test_eccentricity_ratio(a, k):
     ellipse = Ellipse(a, b)
     b, a = sorted([a, b])
     expected = np.sqrt(1 - b ** 2 / a ** 2)
-    assert ellipse.eccentricity == pytest.approx(expected)
+    assert ellipse.eccentricity == approx(expected)
 
 
 @given(
@@ -142,17 +142,17 @@ def test_moment_inertia(a, b, center):
     expected[2] = area * center[0] * center[1]
     np.testing.assert_allclose(ellipse.planar_moments_inertia[:2], expected[:2])
     np.testing.assert_allclose(ellipse.planar_moments_inertia[2], expected[2])
-    assert ellipse.polar_moment_inertia == pytest.approx(sum(expected[:2]))
+    assert ellipse.polar_moment_inertia == approx(sum(expected[:2]))
 
 
 def test_center():
     """Test getting and setting the center."""
     ellipse = Ellipse(1, 2)
-    assert all(ellipse.center == (0, 0, 0))
+    np.testing.assert_allclose(ellipse.center, (0, 0, 0))
 
     center = (1, 1, 1)
     ellipse.center = center
-    assert all(ellipse.center == center)
+    np.testing.assert_allclose(ellipse.center, center)
 
 
 @settings(deadline=500)
@@ -231,8 +231,8 @@ def test_inertia_tensor():
     """Test the inertia tensor calculation."""
     ellipse = Ellipse(1, 2)
     ellipse.center = (0, 0, 0)
-    assert np.sum(ellipse.inertia_tensor > 1e-6) == 1
-    assert ellipse.inertia_tensor[2, 2] == 5 * np.pi / 2
+    assert np.sum(ellipse.inertia_tensor > 1e-6) == approx(1)
+    assert ellipse.inertia_tensor[2, 2] == approx(5 * np.pi / 2)
 
 
 @given(

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -119,7 +119,7 @@ def test_eccentricity_ratio(a, k):
     b = a * k
     ellipse = Ellipse(a, b)
     b, a = sorted([a, b])
-    expected = np.sqrt(1 - b ** 2 / a ** 2)
+    expected = np.sqrt(1 - b**2 / a**2)
     assert ellipse.eccentricity == approx(expected)
 
 
@@ -136,7 +136,7 @@ def test_moment_inertia(a, b, center):
     # calculation is not shifted away from the origin.
     ellipse.center = center
     area = ellipse.area
-    expected = [np.pi / 4 * a * b ** 3, np.pi / 4 * a ** 3 * b, 0]
+    expected = [np.pi / 4 * a * b**3, np.pi / 4 * a**3 * b, 0]
     expected[0] += area * center[0] ** 2
     expected[1] += area * center[1] ** 2
     expected[2] = area * center[0] * center[1]

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -65,7 +65,7 @@ def test_surface_area(a, b, c):
     )
 
     ellipsoid = Ellipsoid(a, b, c)
-    assert ellipsoid.surface_area == pytest.approx(approx_surface, rel=0.015)
+    assert ellipsoid.surface_area == approx(approx_surface, rel=0.015)
 
 
 @given(floats(0.1, 1000))
@@ -86,7 +86,7 @@ def test_volume(a, b, c):
     ellipsoid.a = a
     ellipsoid.b = b
     ellipsoid.c = c
-    assert ellipsoid.volume == 4 / 3 * np.pi * a * b * c
+    assert ellipsoid.volume == approx(4 / 3 * np.pi * a * b * c)
 
 
 @given(floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000))
@@ -114,14 +114,14 @@ def test_earth():
     earth_volume = 1.08e21  # or so, m^3
     earth_surface = 510.1e12  # or so, m^2
     earth = Ellipsoid(a, b, c)
-    assert earth.volume == pytest.approx(earth_volume, rel=1.01)
-    assert earth.surface_area == pytest.approx(earth_surface, rel=1.01)
+    assert earth.volume == approx(earth_volume, rel=1.01)
+    assert earth.surface_area == approx(earth_surface, rel=1.01)
 
 
 @given(floats(0.1, 1000))
 def test_iq(r):
     sphere = Ellipsoid(r, r, r)
-    assert sphere.iq == pytest.approx(1)
+    assert sphere.iq == approx(1)
 
 
 @given(floats(0.1, 1000), floats(0.1, 1000), floats(0.1, 1000))
@@ -129,9 +129,9 @@ def test_iq_symmetry(a, b, c):
     ellipsoid1 = Ellipsoid(a, b, c)
     ellipsoid2 = Ellipsoid(c, a, b)
     ellipsoid3 = Ellipsoid(b, c, a)
-    assert ellipsoid1.iq == pytest.approx(ellipsoid2.iq)
-    assert ellipsoid1.iq == pytest.approx(ellipsoid3.iq)
-    assert ellipsoid2.iq == pytest.approx(ellipsoid3.iq)
+    assert ellipsoid1.iq == approx(ellipsoid2.iq)
+    assert ellipsoid1.iq == approx(ellipsoid3.iq)
+    assert ellipsoid2.iq == approx(ellipsoid3.iq)
 
 
 @given(
@@ -174,11 +174,11 @@ def test_is_inside(a, b, c, center):
 def test_center():
     """Test getting and setting the center."""
     ellipsoid = Ellipsoid(1, 2, 3)
-    assert all(ellipsoid.center == (0, 0, 0))
+    np.testing.assert_allclose(ellipsoid.center, (0, 0, 0))
 
     center = (1, 1, 1)
     ellipsoid.center = center
-    assert all(ellipsoid.center == center)
+    np.testing.assert_allclose(ellipsoid.center, center)
 
 
 @given(

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -61,7 +61,7 @@ def test_surface_area(a, b, c):
     approx_surface = (
         4
         * np.pi
-        * ((a ** p * b ** p + a ** p * c ** p + b ** p * c ** p) / 3) ** (1 / p)
+        * ((a**p * b**p + a**p * c**p + b**p * c**p) / 3) ** (1 / p)
     )
 
     ellipsoid = Ellipsoid(a, b, c)
@@ -146,7 +146,7 @@ def test_inertia_tensor(a, b, c, center):
     assert np.all(ellipsoid.inertia_tensor >= 0)
 
     volume = ellipsoid.volume
-    expected = [2 / 5 * volume * a ** 2] * 3
+    expected = [2 / 5 * volume * a**2] * 3
     np.testing.assert_allclose(np.diag(ellipsoid.inertia_tensor), expected)
 
     ellipsoid.center = center

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -114,8 +114,8 @@ def test_earth():
     earth_volume = 1.08e21  # or so, m^3
     earth_surface = 510.1e12  # or so, m^2
     earth = Ellipsoid(a, b, c)
-    assert earth.volume == approx(earth_volume, rel=1.01)
-    assert earth.surface_area == approx(earth_surface, rel=1.01)
+    assert earth.volume == approx(earth_volume, rel=0.01)
+    assert earth.surface_area == approx(earth_surface, rel=0.01)
 
 
 @given(floats(0.1, 1000))

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -131,21 +131,21 @@ def test_moment_inertia(square):
 def test_inertia_tensor(square):
     """Test the inertia tensor calculation."""
     square.center = (0, 0, 0)
-    assert np.sum(square.inertia_tensor > 1e-6) == approx(1)
+    assert np.sum(square.inertia_tensor > 1e-6) == 1
     np.testing.assert_allclose(square.inertia_tensor[2, 2], 1 / 6)
 
     # Validate yz plane.
     rotation = rowan.from_axis_angle([0, 1, 0], np.pi / 2)
     rotated_verts = rowan.rotate(rotation, square.vertices)
     rotated_square = ConvexPolygon(rotated_verts)
-    assert np.sum(rotated_square.inertia_tensor > 1e-6) == approx(1)
+    assert np.sum(rotated_square.inertia_tensor > 1e-6) == 1
     assert rotated_square.inertia_tensor[0, 0] == approx(1 / 6)
 
     # Validate xz plane.
     rotation = rowan.from_axis_angle([1, 0, 0], np.pi / 2)
     rotated_verts = rowan.rotate(rotation, square.vertices)
     rotated_square = ConvexPolygon(rotated_verts)
-    assert np.sum(rotated_square.inertia_tensor > 1e-6) == approx(1)
+    assert np.sum(rotated_square.inertia_tensor > 1e-6) == 1
     assert rotated_square.inertia_tensor[1, 1] == approx(1 / 6)
 
     # Validate translation along each axis.
@@ -159,7 +159,7 @@ def test_inertia_tensor(square):
         offdiagonal_tensor = translated_square.inertia_tensor.copy()
         diag_indices = np.diag_indices(3)
         offdiagonal_tensor[diag_indices] = 0
-        assert np.sum(offdiagonal_tensor > 1e-6) == approx(0)
+        assert not np.any(offdiagonal_tensor > 1e-6)
         expected_diagonals = [0, 0, 1 / 6]
         for j in range(3):
             if i != j:

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -88,8 +88,8 @@ def test_area(square_points):
     # Shift to ensure that the negative areas are subtracted as needed.
     points = np.asarray(square_points) + 2
     square = Polygon(points)
-    assert square.signed_area == 1
-    assert square.area == 1
+    assert square.signed_area == approx(1)
+    assert square.area == approx(1)
 
 
 def test_set_area(square):
@@ -100,11 +100,11 @@ def test_set_area(square):
 
 def test_center(square, square_points):
     """Test centering the polygon."""
-    assert np.all(square.center == np.mean(square_points, axis=0))
-    assert np.all(square.centroid == np.mean(square_points, axis=0))
+    np.testing.assert_allclose(square.center, np.mean(square_points, axis=0))
+    np.testing.assert_allclose(square.centroid, np.mean(square_points, axis=0))
     square.center = [0, 0, 0]
-    assert np.all(square.center == [0, 0, 0])
-    assert np.all(square.centroid == [0, 0, 0])
+    np.testing.assert_allclose(square.center, [0, 0, 0])
+    np.testing.assert_allclose(square.centroid, [0, 0, 0])
 
 
 def test_moment_inertia(square):
@@ -131,22 +131,22 @@ def test_moment_inertia(square):
 def test_inertia_tensor(square):
     """Test the inertia tensor calculation."""
     square.center = (0, 0, 0)
-    assert np.sum(square.inertia_tensor > 1e-6) == 1
-    assert square.inertia_tensor[2, 2] == 1 / 6
+    assert np.sum(square.inertia_tensor > 1e-6) == approx(1)
+    np.testing.assert_allclose(square.inertia_tensor[2, 2], 1 / 6)
 
     # Validate yz plane.
     rotation = rowan.from_axis_angle([0, 1, 0], np.pi / 2)
     rotated_verts = rowan.rotate(rotation, square.vertices)
     rotated_square = ConvexPolygon(rotated_verts)
-    assert np.sum(rotated_square.inertia_tensor > 1e-6) == 1
-    assert rotated_square.inertia_tensor[0, 0] == 1 / 6
+    assert np.sum(rotated_square.inertia_tensor > 1e-6) == approx(1)
+    assert rotated_square.inertia_tensor[0, 0] == approx(1 / 6)
 
     # Validate xz plane.
     rotation = rowan.from_axis_angle([1, 0, 0], np.pi / 2)
     rotated_verts = rowan.rotate(rotation, square.vertices)
     rotated_square = ConvexPolygon(rotated_verts)
-    assert np.sum(rotated_square.inertia_tensor > 1e-6) == 1
-    assert rotated_square.inertia_tensor[1, 1] == 1 / 6
+    assert np.sum(rotated_square.inertia_tensor > 1e-6) == approx(1)
+    assert rotated_square.inertia_tensor[1, 1] == approx(1 / 6)
 
     # Validate translation along each axis.
     delta = 2
@@ -159,7 +159,7 @@ def test_inertia_tensor(square):
         offdiagonal_tensor = translated_square.inertia_tensor.copy()
         diag_indices = np.diag_indices(3)
         offdiagonal_tensor[diag_indices] = 0
-        assert np.sum(offdiagonal_tensor > 1e-6) == 0
+        assert np.sum(offdiagonal_tensor > 1e-6) == approx(0)
         expected_diagonals = [0, 0, 1 / 6]
         for j in range(3):
             if i != j:
@@ -286,8 +286,8 @@ def test_circumcircle_radius(poly):
 
 def test_maximal_centered_bounded_circle(convex_square):
     circle = convex_square.maximal_centered_bounded_circle
-    assert np.all(circle.center == convex_square.center)
-    assert circle.radius == 0.5
+    np.testing.assert_allclose(circle.center, convex_square.center)
+    assert circle.radius == approx(0.5)
 
     with pytest.deprecated_call():
         assert sphere_isclose(convex_square.incircle_from_center, circle)
@@ -384,8 +384,9 @@ def test_set_perimeter(square_points):
     def testfun(value):
         square.perimeter = value
         assert square.perimeter == approx(value)
-        assert square.vertices == approx(
-            original_square.vertices * (value / original_square.perimeter)
+        np.testing.assert_allclose(
+            square.vertices,
+            original_square.vertices * (value / original_square.perimeter),
         )
 
     testfun()

--- a/tests/test_polyhedron.py
+++ b/tests/test_polyhedron.py
@@ -29,9 +29,12 @@ from utils import compute_centroid_mc, compute_inertia_mc
 
 
 def test_normal_detection(convex_cube):
-    detected_normals = set([tuple(n) for n in convex_cube.normals])
-    expected_normals = set([tuple(n) for n in get_oriented_cube_normals()])
-    assert detected_normals == expected_normals
+    detected_normals = [tuple(n) for n in convex_cube.normals]
+    expected_normals = [tuple(n) for n in get_oriented_cube_normals()]
+    for dn in detected_normals:
+        # Each detected normal should be identical to exactly one expected
+        # normal. No ordering is guaranteed, so we have to check them all.
+        assert sum([np.allclose(dn, en) for en in expected_normals]) == 1
 
 
 @pytest.mark.parametrize(
@@ -39,7 +42,7 @@ def test_normal_detection(convex_cube):
 )
 def test_surface_area(cube):
     """Test surface area calculation."""
-    assert cube.surface_area == 6
+    assert cube.surface_area == approx(6)
 
 
 @pytest.mark.parametrize(
@@ -57,7 +60,7 @@ def test_set_surface_area(cube):
     "cube", ["convex_cube", "oriented_cube", "unoriented_cube"], indirect=True
 )
 def test_volume(cube):
-    assert cube.volume == 1
+    assert cube.volume == approx(1)
 
 
 @pytest.mark.parametrize(
@@ -199,7 +202,7 @@ def test_moment_inertia_damasceno_shapes(shape):
     "cube", ["convex_cube", "oriented_cube", "unoriented_cube"], indirect=True
 )
 def test_iq(cube):
-    assert cube.iq == 36 * np.pi * cube.volume ** 2 / cube.surface_area ** 3
+    assert cube.iq == approx(36 * np.pi * cube.volume ** 2 / cube.surface_area ** 3)
 
 
 def test_dihedrals():
@@ -373,7 +376,7 @@ def test_inside(convex_cube):
     def testfun(test_points):
         expected = np.all(np.logical_and(test_points >= 0, test_points <= 1), axis=1)
         actual = convex_cube.is_inside(test_points)
-        assert np.all(expected == actual)
+        np.testing.assert_allclose(expected, actual)
 
     testfun()
 

--- a/tests/test_polyhedron.py
+++ b/tests/test_polyhedron.py
@@ -202,7 +202,7 @@ def test_moment_inertia_damasceno_shapes(shape):
     "cube", ["convex_cube", "oriented_cube", "unoriented_cube"], indirect=True
 )
 def test_iq(cube):
-    assert cube.iq == approx(36 * np.pi * cube.volume ** 2 / cube.surface_area ** 3)
+    assert cube.iq == approx(36 * np.pi * cube.volume**2 / cube.surface_area**3)
 
 
 def test_dihedrals():
@@ -274,20 +274,20 @@ def test_circumsphere_platonic(poly):
 
     # Ensure polyhedron is centered, then compute distances.
     poly.center = [0, 0, 0]
-    r2 = np.sum(poly.vertices ** 2, axis=1)
+    r2 = np.sum(poly.vertices**2, axis=1)
 
-    assert np.allclose(r2, circumsphere.radius ** 2)
+    assert np.allclose(r2, circumsphere.radius**2)
 
 
 @named_platonic_mark
 def test_circumsphere_radius_platonic(poly):
     # Ensure polyhedron is centered, then compute distances.
     poly.center = [0, 0, 0]
-    r2 = np.sum(poly.vertices ** 2, axis=1)
+    r2 = np.sum(poly.vertices**2, axis=1)
 
-    assert np.allclose(r2, poly.circumsphere_radius ** 2)
+    assert np.allclose(r2, poly.circumsphere_radius**2)
     poly.circumsphere_radius *= 2
-    assert np.allclose(r2 * 4, poly.circumsphere_radius ** 2)
+    assert np.allclose(r2 * 4, poly.circumsphere_radius**2)
 
 
 def test_minimal_centered_bounding_sphere():
@@ -350,10 +350,10 @@ def test_minimal_centered_bounding_sphere():
 def test_bounding_sphere_platonic(poly):
     # Ensure polyhedron is centered, then compute distances.
     poly.center = [0, 0, 0]
-    r2 = np.sum(poly.vertices ** 2, axis=1)
+    r2 = np.sum(poly.vertices**2, axis=1)
 
     bounding_sphere = poly.minimal_bounding_sphere
-    assert np.allclose(r2, bounding_sphere.radius ** 2, rtol=1e-4)
+    assert np.allclose(r2, bounding_sphere.radius**2, rtol=1e-4)
 
     with pytest.deprecated_call():
         assert sphere_isclose(bounding_sphere, poly.bounding_sphere)

--- a/tests/test_shape_families.py
+++ b/tests/test_shape_families.py
@@ -80,11 +80,11 @@ def test_shape523():
     family = Family523
     s = family.s
     # Icosidodecahedron
-    assert len(family.get_shape(1, family.S ** 2).vertices) == 30
-    assert len(family.get_shape(1, family.S ** 2).faces) == 32
+    assert len(family.get_shape(1, family.S**2).vertices) == 30
+    assert len(family.get_shape(1, family.S**2).faces) == 32
     # Icosahedron
-    assert len(family.get_shape(1 * s * np.sqrt(5), family.S ** 2).vertices) == 12
-    assert len(family.get_shape(1 * s * np.sqrt(5), family.S ** 2).faces) == 20
+    assert len(family.get_shape(1 * s * np.sqrt(5), family.S**2).vertices) == 12
+    assert len(family.get_shape(1 * s * np.sqrt(5), family.S**2).faces) == 20
     # Dodecahedron
     assert len(family.get_shape(1, 3).vertices) == 20
     assert len(family.get_shape(1, 3).faces) == 12

--- a/tests/test_shape_getters.py
+++ b/tests/test_shape_getters.py
@@ -2,6 +2,7 @@
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 import numpy as np
+from pytest import approx
 
 from coxeter import from_gsd_type_shapes
 
@@ -77,9 +78,9 @@ def test_gsd_shape_getter():
         shape = from_gsd_type_shapes(shape_spec, dimensions=dimensions)
         for param, value in shape_spec.items():
             if param == "diameter":
-                assert shape.radius == value / 2
+                assert shape.radius == approx(value / 2)
             elif param == "rounding_radius":
-                assert shape.radius == value
+                assert shape.radius == approx(value)
             elif param != "type":
                 try:
                     assert getattr(shape, param) == value

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -32,14 +32,14 @@ def test_invalid_radius_setter(r):
 def test_surface_area(r):
     sphere = Sphere(1)
     sphere.radius = r
-    assert sphere.surface_area == approx(4 * np.pi * r ** 2)
+    assert sphere.surface_area == approx(4 * np.pi * r**2)
 
 
 @given(floats(0.1, 1000))
 def test_volume(r):
     sphere = Sphere(1)
     sphere.radius = r
-    assert sphere.volume == approx(4 / 3 * np.pi * r ** 3)
+    assert sphere.volume == approx(4 / 3 * np.pi * r**3)
 
 
 @given(floats(-1000, -1))
@@ -90,8 +90,8 @@ def test_inertia_tensor(r, center):
     sphere = Sphere(r)
     assert np.all(sphere.inertia_tensor >= 0)
 
-    volume = 4 / 3 * np.pi * r ** 3
-    expected = [2 / 5 * volume * r ** 2] * 3
+    volume = 4 / 3 * np.pi * r**3
+    expected = [2 / 5 * volume * r**2] * 3
     np.testing.assert_allclose(np.diag(sphere.inertia_tensor), expected)
 
     sphere.center = center

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -32,14 +32,14 @@ def test_invalid_radius_setter(r):
 def test_surface_area(r):
     sphere = Sphere(1)
     sphere.radius = r
-    assert sphere.surface_area == 4 * np.pi * r ** 2
+    assert sphere.surface_area == approx(4 * np.pi * r ** 2)
 
 
 @given(floats(0.1, 1000))
 def test_volume(r):
     sphere = Sphere(1)
     sphere.radius = r
-    assert sphere.volume == 4 / 3 * np.pi * r ** 3
+    assert sphere.volume == approx(4 / 3 * np.pi * r ** 3)
 
 
 @given(floats(-1000, -1))
@@ -79,7 +79,7 @@ def test_invalid_area_setter(area):
 @given(floats(0.1, 1000))
 def test_iq(r):
     sphere = Sphere(r)
-    assert sphere.iq == 1
+    assert sphere.iq == approx(1)
 
 
 @given(
@@ -111,11 +111,11 @@ def test_is_inside(x, center):
 def test_center():
     """Test getting and setting the center."""
     sphere = Sphere(1)
-    assert all(sphere.center == (0, 0, 0))
+    np.testing.assert_allclose(sphere.center, (0, 0, 0))
 
     center = (1, 1, 1)
     sphere.center = center
-    assert all(sphere.center == center)
+    np.testing.assert_allclose(sphere.center, center)
 
 
 def test_form_factor():

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -79,7 +79,7 @@ def test_invalid_area_setter(area):
 @given(floats(0.1, 1000))
 def test_iq(r):
     sphere = Sphere(r)
-    assert sphere.iq == approx(1)
+    assert sphere.iq == 1
 
 
 @given(

--- a/tests/test_spheropolygon.py
+++ b/tests/test_spheropolygon.py
@@ -50,9 +50,9 @@ def test_radius_getter_setter(square_points):
     def testfun(r):
         square_points_2d = square_points[:, :2]
         convexspheropolygon = ConvexSpheropolygon(square_points_2d, r)
-        assert convexspheropolygon.radius == r
+        assert convexspheropolygon.radius == approx(r)
         convexspheropolygon.radius = r + 1
-        assert convexspheropolygon.radius == r + 1
+        assert convexspheropolygon.radius == approx(r + 1)
 
     testfun()
 
@@ -99,8 +99,8 @@ def test_area(unit_rounded_square):
     """Test area calculation."""
     shape = unit_rounded_square
     area = 1 + 4 + np.pi
-    assert shape.signed_area == area
-    assert shape.area == area
+    assert shape.signed_area == approx(area)
+    assert shape.area == approx(area)
 
 
 def test_area_getter_setter(unit_rounded_square):
@@ -172,7 +172,7 @@ def test_convex_signed_area(square_points):
 
 def test_sphero_square_perimeter(unit_rounded_square):
     """Test calculating the perimeter of a spheropolygon."""
-    assert unit_rounded_square.perimeter == 4 + 2 * np.pi
+    assert unit_rounded_square.perimeter == approx(4 + 2 * np.pi)
 
 
 def test_perimeter_setter(unit_rounded_square):

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -14,8 +14,8 @@ from conftest import make_sphero_cube
 def test_volume(radius):
     sphero_cube = make_sphero_cube(radius=radius)
     v_cube = 1
-    v_sphere = (4 / 3) * np.pi * radius ** 3
-    v_cyl = 12 * (np.pi * radius ** 2) / 4
+    v_sphere = (4 / 3) * np.pi * radius**3
+    v_cyl = 12 * (np.pi * radius**2) / 4
     v_face = sphero_cube.polyhedron.surface_area * radius
     assert np.isclose(sphero_cube.volume, v_cube + v_sphere + v_face + v_cyl)
 
@@ -37,7 +37,7 @@ def test_set_volume(value):
 def test_surface_area(radius):
     sphero_cube = make_sphero_cube(radius=radius)
     sa_cube = 6
-    sa_sphere = 4 * np.pi * radius ** 2
+    sa_sphere = 4 * np.pi * radius**2
     sa_cyl = 12 * (2 * np.pi * radius) / 4
     assert np.isclose(sphero_cube.surface_area, sa_cube + sa_sphere + sa_cyl)
 

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -23,7 +23,7 @@ def test_volume(radius):
 def test_volume_polyhedron(convex_cube, cube_points):
     """Ensure that zero radius gives the same result as a polyhedron."""
     sphero_cube = make_sphero_cube(radius=0)
-    assert sphero_cube.volume == convex_cube.volume
+    assert sphero_cube.volume == approx(convex_cube.volume)
 
 
 @given(value=floats(0.1, 1))
@@ -52,7 +52,7 @@ def test_set_surface_area(value):
 def test_surface_area_polyhedron(convex_cube):
     """Ensure that zero radius gives the same result as a polyhedron."""
     sphero_cube = make_sphero_cube(radius=0)
-    assert sphero_cube.surface_area == convex_cube.surface_area
+    assert sphero_cube.surface_area == approx(convex_cube.surface_area)
 
 
 @given(r=floats(0, 1.0))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Swap exact equality comparisons in tests with comparisons using `pytest.approx` or `numpy.testing.assert_allclose`.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves #158.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
