### PR TITLE
Fix Readthedocs build error by switching dependency installs to mamba

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,8 @@
 version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "mambaforge-4.10"
 formats:
     - htmlzip
 conda:


### PR DESCRIPTION

## Description
Dependency installs performed during the readthedocs build fail due to lack of memory. Switching to installs via mamba (rather than conda) should fix this error

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
