### PR TITLE
Fixed documentation for common families

### DIFF
--- a/coxeter/families/common.py
+++ b/coxeter/families/common.py
@@ -138,7 +138,7 @@ PyramidDipyramidFamily = TabulatedGSDShapeFamily.from_json_file(
     docstring="""The family of regular equilateral pyramids and dipyramids (6 total).
 
     The following parameters are required by this class:
-    
+
     - name: The name of the pyramid or dipyramid. Options are "Triangular Pyramid", \
             "Square Pyramid", "Pentagonal Pyramid", "Triangular Dipyramid", \
             "Square Dipyramid", and "Pentagonal Dipyramid".

--- a/coxeter/families/common.py
+++ b/coxeter/families/common.py
@@ -75,7 +75,7 @@ class RegularNGonFamily(ShapeFamily):
 PlatonicFamily = TabulatedGSDShapeFamily.from_json_file(
     os.path.join(_DATA_FOLDER, "platonic.json"),
     classname="PlatonicFamily",
-    docstring="""The family of Platonic solids.
+    docstring="""The family of Platonic solids (5 total).
 
 The following parameters are required by this class:
 
@@ -88,6 +88,7 @@ ArchimedeanFamily = TabulatedGSDShapeFamily.from_json_file(
     os.path.join(_DATA_FOLDER, "archimedean.json"),
     classname="ArchimedeanFamily",
     docstring="""The family of Archimedean solids (13 total).
+
 The following parameters are required by this class:
     - name: The name of the ArchimedeanFamily solid. Options are "Cuboctahedron", \
             "Icosidodecahedron", "Truncated Tetrahedron", "Truncated Octahedron", \
@@ -101,8 +102,9 @@ The following parameters are required by this class:
 CatalanFamily = TabulatedGSDShapeFamily.from_json_file(
     os.path.join(_DATA_FOLDER, "catalan.json"),
     classname="CatalanFamily",
-    docstring="""The family of Catalan solids, also known as Archimedean duals
+    docstring="""The family of Catalan solids, also known as Archimedean duals \
     (13 total).
+
 The following parameters are required by this class:
     - name: The name of the CatalanFamily solid. Options are "Deltoidal  \
             Hexecontahedron", "Deltoidal Icositetrahedron", "Disdyakis \
@@ -117,10 +119,12 @@ The following parameters are required by this class:
 JohnsonFamily = TabulatedGSDShapeFamily.from_json_file(
     os.path.join(_DATA_FOLDER, "johnson.json"),
     classname="JohnsonFamily",
-    docstring="""The family of Johnson solids (92 total).
+    docstring="""The family of Johnson solids, as enumerated in \
+    :cite:`Johnson1966` (92 total).
+
 The following parameters are required by this class:
     - name: The name of the JohnsonFamily solid. A full list is available in \
-            10.1126/science.1220869: :cite:`Damasceno2012`. In general, shape names \
+            :cite:`Johnson1966`. In general, shape names \
             should have the first character of each word capitalized, with spaces \
             between words (e.g. "Elongated Triangular Cupola"). Pyramids and \
             dipyramids are named from their base polygon (e.g. "Square Pyramid" \
@@ -128,12 +132,12 @@ The following parameters are required by this class:
 """,
 )
 
-
 PyramidDipyramidFamily = TabulatedGSDShapeFamily.from_json_file(
     os.path.join(_DATA_FOLDER, "pyramid_dipyramid.json"),
     classname="PyramidDipyramidFamily",
     docstring="""The family of regular equilateral pyramids and dipyramids (6 total).
-The following parameters are required by this class:
+
+    The following parameters are required by this class:
     - name: The name of the pyramid or dipyramid. Options are "Triangular Pyramid", \
             "Square Pyramid", "Pentagonal Pyramid", "Triangular Dipyramid", \
             "Square Dipyramid", and "Pentagonal Dipyramid".
@@ -143,8 +147,10 @@ The following parameters are required by this class:
 PrismAntiprismFamily = TabulatedGSDShapeFamily.from_json_file(
     os.path.join(_DATA_FOLDER, "prism_antiprism.json"),
     classname="PrismAntiprismFamily",
-    docstring="""The family of n-gonal prisms and antiprisms with n∈[3,10] (16 total).
-The following parameters are required by this class:
+    docstring="""The family of uniform n-prisms and n-antiprisms with n∈[3,10] \
+    (16 total).
+
+    The following parameters are required by this class:
     - name: The name of the prism or antiprism. Options for prisms are  \
             "Triangular Prism", "Square Prism", "Pentagonal Prism", "Hexagonal Prism", \
             "Heptagonal Prism", "Octagonal Prism", "Nonagonal Prism", and \

--- a/coxeter/families/common.py
+++ b/coxeter/families/common.py
@@ -138,6 +138,7 @@ PyramidDipyramidFamily = TabulatedGSDShapeFamily.from_json_file(
     docstring="""The family of regular equilateral pyramids and dipyramids (6 total).
 
     The following parameters are required by this class:
+    
     - name: The name of the pyramid or dipyramid. Options are "Triangular Pyramid", \
             "Square Pyramid", "Pentagonal Pyramid", "Triangular Dipyramid", \
             "Square Dipyramid", and "Pentagonal Dipyramid".

--- a/coxeter/families/common.py
+++ b/coxeter/families/common.py
@@ -77,10 +77,11 @@ PlatonicFamily = TabulatedGSDShapeFamily.from_json_file(
     classname="PlatonicFamily",
     docstring="""The family of Platonic solids (5 total).
 
-The following parameters are required by this class:
+    Args:
+        name (str):
+                The name of the Platonic solid.
 
-    - name: The name of the Platonic solid. Options are "Cube", "Dodecahedron", \
-            "Icosahedron", "Octahedron", and "Tetrahedron".
+    Options are "Cube", "Dodecahedron", "Icosahedron", "Octahedron", and "Tetrahedron".
 """,
 )
 
@@ -89,13 +90,15 @@ ArchimedeanFamily = TabulatedGSDShapeFamily.from_json_file(
     classname="ArchimedeanFamily",
     docstring="""The family of Archimedean solids (13 total).
 
-The following parameters are required by this class:
-    - name: The name of the ArchimedeanFamily solid. Options are "Cuboctahedron", \
-            "Icosidodecahedron", "Truncated Tetrahedron", "Truncated Octahedron", \
-            "Truncated Cube", "Truncated Icosahedron", "Truncated Dodecahedron", \
-            "Rhombicuboctahedron", "Rhombicosidodecahedron", "Truncated \
-            Cuboctahedron", "Truncated Icosidodecahedron", "Snub Cuboctahedron", \
-            and "Snub Icosidodecahedron".
+    Args:
+        name (str):
+                The name of the Archimedean solid.
+
+    Options are "Cuboctahedron", "Icosidodecahedron", "Truncated Tetrahedron",
+    "Truncated Octahedron", "Truncated Cube", "Truncated Icosahedron", "Truncated
+    Dodecahedron", "Rhombicuboctahedron", "Rhombicosidodecahedron", "Truncated \
+    Cuboctahedron", "Truncated Icosidodecahedron", "Snub Cuboctahedron", and "Snub
+    Icosidodecahedron".
 """,
 )
 
@@ -105,14 +108,15 @@ CatalanFamily = TabulatedGSDShapeFamily.from_json_file(
     docstring="""The family of Catalan solids, also known as Archimedean duals \
     (13 total).
 
-The following parameters are required by this class:
-    - name: The name of the CatalanFamily solid. Options are "Deltoidal  \
-            Hexecontahedron", "Deltoidal Icositetrahedron", "Disdyakis \
-            Dodecahedron", "Disdyakis Triacontahedron", "Pentagonal \
-            Hexecontahedron", "Pentagonal Icositetrahedron", "Pentakis \
-            Dodecahedron", "Rhombic Dodecahedron", "Rhombic \
-            Triacontahedron", "Triakis Octahedron", "Tetrakis \
-            Hexahedron", "Triakis Icosahedron", and "Triakis Tetrahedron".
+    Args:
+        name (str):
+                The name of the Catalan solid.
+
+    Options are "Deltoidal Hexecontahedron", "Deltoidal Icositetrahedron", "Disdyakis \
+    Dodecahedron", "Disdyakis Triacontahedron", "Pentagonal Hexecontahedron",
+    "Pentagonal Icositetrahedron", "Pentakis Dodecahedron", "Rhombic Dodecahedron",
+    "Rhombic Triacontahedron", "Triakis Octahedron", "Tetrakis Hexahedron", "Triakis
+    Icosahedron", and "Triakis Tetrahedron".
 """,
 )
 
@@ -122,13 +126,14 @@ JohnsonFamily = TabulatedGSDShapeFamily.from_json_file(
     docstring="""The family of Johnson solids, as enumerated in \
     :cite:`Johnson1966` (92 total).
 
-The following parameters are required by this class:
-    - name: The name of the JohnsonFamily solid. A full list is available in \
-            :cite:`Johnson1966`. In general, shape names \
-            should have the first character of each word capitalized, with spaces \
-            between words (e.g. "Elongated Triangular Cupola"). Pyramids and \
-            dipyramids are named from their base polygon (e.g. "Square Pyramid" \
-            or "Elongated Pentagonal Dipyramid").
+    Args:
+        name (str):
+                The name of the Johnson solid.
+
+    A full list of Johnson solids is available in :cite:`Johnson1966`. In general, shape
+    names should have the first character of each word capitalized, with spaces between
+    words (e.g. "Elongated Triangular Cupola"). Pyramids and dipyramids are named from
+    their base polygon (e.g. "Square Pyramid" or "Elongated Pentagonal Dipyramid").
 """,
 )
 
@@ -137,11 +142,13 @@ PyramidDipyramidFamily = TabulatedGSDShapeFamily.from_json_file(
     classname="PyramidDipyramidFamily",
     docstring="""The family of regular equilateral pyramids and dipyramids (6 total).
 
-    The following parameters are required by this class:
+    Args:
+        name (str):
+                The name of the pyramid or dipyramid.
 
-    - name: The name of the pyramid or dipyramid. Options are "Triangular Pyramid", \
-            "Square Pyramid", "Pentagonal Pyramid", "Triangular Dipyramid", \
-            "Square Dipyramid", and "Pentagonal Dipyramid".
+    Options for pyramids are "Triangular Pyramid", "Square Pyramid", and
+    "Pentagonal Pyramid". Options for dipyramids are "Triangular Dipyramid",
+    "Square Dipyramid", and "Pentagonal Dipyramid".
 """,
 )
 
@@ -151,13 +158,16 @@ PrismAntiprismFamily = TabulatedGSDShapeFamily.from_json_file(
     docstring="""The family of uniform n-prisms and n-antiprisms with n∈[3,10] \
     (16 total).
 
-    The following parameters are required by this class:
-    - name: The name of the prism or antiprism. Options for prisms are  \
-            "Triangular Prism", "Square Prism", "Pentagonal Prism", "Hexagonal Prism", \
-            "Heptagonal Prism", "Octagonal Prism", "Nonagonal Prism", and \
-            "Decagonal Prism". Options for antiprisms are "Triangular Antiprism", \
-            "Square Antiprism", "Pentagonal Antiprism", "Hexagonal Antiprism", \
-            "Heptagonal Antiprism", "Octagonal Antiprism","Nonagonal Antiprism", \
-            and "Decagonal Antiprism".
+    Args:
+        name (str):
+                The name of the prism or antiprism.
+
+    Options for prisms are  \
+    "Triangular Prism", "Square Prism", "Pentagonal Prism", "Hexagonal Prism", \
+    "Heptagonal Prism", "Octagonal Prism", "Nonagonal Prism", and \
+    "Decagonal Prism". Options for antiprisms are "Triangular Antiprism", \
+    "Square Antiprism", "Pentagonal Antiprism", "Hexagonal Antiprism", \
+    "Heptagonal Antiprism", "Octagonal Antiprism","Nonagonal Antiprism", \
+    and "Decagonal Antiprism".
 """,
 )

--- a/doc/source/coxeter.bib
+++ b/doc/source/coxeter.bib
@@ -50,6 +50,17 @@ publisher = {American Physical Society},
 doi = {10.1103/PhysRevX.4.011024},
 }
 
+@article{Johnson1966,
+title={Convex Polyhedra with Regular Faces},
+author={Johnson, Norman W.},
+journal={Canadian Journal of Mathematics},
+volume={18},
+pages={169–200},
+year={1966},
+publisher={Cambridge University Press},
+doi={10.4153/cjm-1966-021-8},
+}
+
 @article{Damasceno2012,
 author = {Damasceno, Pablo F. and Engel, Michael and Glotzer, Sharon C.},
 title = {Crystalline Assemblies and Densest Packings of a Family of Truncated Tetrahedra and the Role of Directional Entropic Forces},


### PR DESCRIPTION
## Description
A few of the families defined in #177 have messy documentation that result from missing line breaks. This has been addressed, and the short docstrings (which display in the Classes table on readthedocs) have been made more uniform.

## Types of Changes
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
<sup>These changes fix a PR that I authored, so I have not modified the changelog.</sup>
