### PR TITLE
Fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
         exclude: '(?:setup.cfg.*|paper/.*)'
       - id: debug-statements
       - id: pretty-format-json
+        exclude: '\.ipynb$'
         args:
         - --indent
         - '4'


### PR DESCRIPTION
Pre-commit update to 3.4 update breakes pretty json linter which attempts to lint ipython notebooks in docs and fails.

## Description
Pre-commit update to 3.4 update breakes pretty json linter which attempts to lint ipython notebooks in docs and fails. This is not observed in 3.3 pre-commit version. 


## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
