### PR TITLE
Correct Spheropolyhedron Class

### DIFF
--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -56,6 +56,27 @@ def test_surface_area_polyhedron(convex_cube):
     assert sphero_cube.surface_area == approx(convex_cube.surface_area)
 
 
+@given(radius=floats(0.1, 1))
+def test_mean_curvature(radius):
+    sphero_cube = make_sphero_cube(radius=radius)
+    h_cube = 3 / 4
+    h_sphere = radius
+    assert np.isclose(sphero_cube.mean_curvature, h_cube + h_sphere)
+
+
+def test_mean_curvature_polyhedron(convex_cube, cube_points):
+    """Ensure that zero radius gives the same result as a polyhedron."""
+    sphero_cube = make_sphero_cube(radius=0)
+    assert sphero_cube.mean_curvature == approx(convex_cube.mean_curvature)
+
+
+@given(value=floats(0.1, 1))
+def test_set_mean_curvature(value):
+    sphero_cube = make_sphero_cube(radius=0)
+    sphero_cube.mean_curvature = value
+    assert sphero_cube.mean_curvature == approx(value)
+
+
 @given(r=floats(0, 1.0))
 def test_radius_getter_setter(r):
     sphero_cube = make_sphero_cube(radius=r)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
There is an error in the method via which coxeter currently computes the volumes and surface area of speropolyhedra. Part of the sums of the volume & SA are based on fractions of cylinders that extend from the edges of the base polyhedron. The included angle of this cylinder is equal to the angle between the normals of the two adjoining faces, which is equal to $\pi - \phi$, where $\phi$ is the dihedral (see e.g. equation (9) of Eric, I. M., & Michael, E. (2017). Virial Coefficients and Equations of State for Hard Polyhedron Fluids). Currently the sum is calculated only as $\phi$. While this gives correct results for the test case of a cube ($\pi/2 = \pi - \pi/2$), it does not for non-orthogonal geometries.

In addition, the mean curvature of the spherobody is implemented. The (normalized) integral mean curvature is just the sum of the mean curvature of the base shape and the radius.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
- To correct the surface area and volume functions for speropolyhedra
- To add a mean curvature property to the speropolyhedra class
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ x] Bug fix
- [ x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [ x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [ ]x I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [ x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
