### PR TITLE
xfail test_spheropolyhedron.py::to_hoomd

### DIFF
--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -143,7 +143,8 @@ def test_repr():
     assert str(sphero_cube), str(eval(repr(sphero_cube)))
 
 
-@given(r=floats(0.01, 0.95))
+@pytest.mark.xfail(reason="Rounding radius is shape-dependent")
+@given(r=floats(0.01, 1.0))
 @named_catalan_mark
 def test_to_hoomd(poly, r):
     poly.centroid = [0, 0, 0]

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -143,8 +143,7 @@ def test_repr():
     assert str(sphero_cube), str(eval(repr(sphero_cube)))
 
 
-@pytest.mark.xfail(reason="Maximum rounding radius is shape-dependent.")
-@given(r=floats(0.01, 1))
+@given(r=floats(0.01, 0.95))
 @named_catalan_mark
 def test_to_hoomd(poly, r):
     poly.centroid = [0, 0, 0]

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -6,7 +6,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis.strategies import floats
 
-from conftest import make_sphero_cube, named_archimedean_mark
+from conftest import make_sphero_cube
 from coxeter.shapes import ConvexSpheropolyhedron
 
 
@@ -143,8 +143,8 @@ def test_repr():
     assert str(sphero_cube), str(eval(repr(sphero_cube)))
 
 
+@pytest.mark.xfail(reason="Maximum rounding radius is shape-dependent.")
 @given(r=floats(0.01, 1.0))
-@named_archimedean_mark
 def test_to_hoomd(poly, r):
     poly.centroid = [0, 0, 0]
     poly = ConvexSpheropolyhedron(poly.vertices, r)

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -6,7 +6,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis.strategies import floats
 
-from conftest import make_sphero_cube, named_catalan_mark
+from conftest import make_sphero_cube
 from coxeter.shapes import ConvexSpheropolyhedron
 
 

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -142,6 +142,7 @@ def test_repr():
     sphero_cube = make_sphero_cube(radius=1)
     assert str(sphero_cube), str(eval(repr(sphero_cube)))
 
+
 @pytest.mark.xfail(reason="Maximum rounding radius is shape-dependent.")
 @given(r=floats(0.01, 1))
 @named_catalan_mark

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -143,9 +143,8 @@ def test_repr():
     assert str(sphero_cube), str(eval(repr(sphero_cube)))
 
 
-@pytest.mark.xfail(reason="Rounding radius is shape-dependent")
 @given(r=floats(0.01, 1.0))
-@named_catalan_mark
+@named_archimedean_mark
 def test_to_hoomd(poly, r):
     poly.centroid = [0, 0, 0]
     poly = ConvexSpheropolyhedron(poly.vertices, r)

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -142,7 +142,7 @@ def test_repr():
     sphero_cube = make_sphero_cube(radius=1)
     assert str(sphero_cube), str(eval(repr(sphero_cube)))
 
-
+@pytest.mark.xfail(reason="Maximum rounding radius is shape-dependent.")
 @given(r=floats(0.01, 1))
 @named_catalan_mark
 def test_to_hoomd(poly, r):

--- a/tests/test_spheropolyhedron.py
+++ b/tests/test_spheropolyhedron.py
@@ -6,7 +6,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis.strategies import floats
 
-from conftest import make_sphero_cube
+from conftest import make_sphero_cube, named_archimedean_mark
 from coxeter.shapes import ConvexSpheropolyhedron
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description


Occasionally, the random rounding radius assigned to a convex spheropolyhedron in the `to_hoomd` test results in an invalid shape. This mainly happens with the many-faced catalan solids, where edge cylinders overlap in an unpredictable way. I have xfailed this test for now, but we should add some error checking to the ConvexSpheropolyhedron class to prevent undefined behavior.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.txt) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
