### PR TITLE
Fix to_hoomd for convex polygons

### DIFF
--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -800,6 +800,7 @@ class Polygon(Shape2D):
         self.centroid = np.array([0, 0, 0])
         data = self.to_json(["vertices", "centroid", "area", "inertia_tensor"])
         hoomd_dict = _map_dict_keys(data, key_mapping=_hoomd_dict_mapping)
+        hoomd_dict |= {"vertices": self.vertices[:, :2]}
         hoomd_dict["sweep_radius"] = 0.0
 
         self.centroid = old_centroid

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -800,7 +800,7 @@ class Polygon(Shape2D):
         self.centroid = np.array([0, 0, 0])
         data = self.to_json(["vertices", "centroid", "area", "inertia_tensor"])
         hoomd_dict = _map_dict_keys(data, key_mapping=_hoomd_dict_mapping)
-        hoomd_dict |= {"vertices": self.vertices[:, :2]}
+        hoomd_dict = {**hoomd_dict, **{"vertices": self.vertices[:, :2]}}
         hoomd_dict["sweep_radius"] = 0.0
 
         self.centroid = old_centroid

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -603,7 +603,7 @@ def test_to_hoomd(points):
     poly.centroid = [0, 0, 0]
     dict_keys = ["vertices", "centroid", "sweep_radius", "area", "moment_inertia"]
     dict_vals = [
-        poly.vertices[:,:2],
+        poly.vertices[:, :2],
         [0, 0, 0],
         0,
         poly.area,

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -603,7 +603,7 @@ def test_to_hoomd(points):
     poly.centroid = [0, 0, 0]
     dict_keys = ["vertices", "centroid", "sweep_radius", "area", "moment_inertia"]
     dict_vals = [
-        poly.vertices,
+        poly.vertices[:,:2],
         [0, 0, 0],
         0,
         poly.area,


### PR DESCRIPTION
## Description
 
HOOMD expects an (N,2) array instead of the (N,3) representation coxeter uses for polygons. 

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.rst) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
