### PR TITLE
Switch HTTP to HTTPS protocol for script url in page template

### DIFF
--- a/doc/source/_templates/page.html
+++ b/doc/source/_templates/page.html
@@ -2,7 +2,7 @@
 
 {%- block extrahead %}
 
-<script type="text/javascript" src="http://x3dom.org/release/x3dom.js"> </script>
+<script type="text/javascript" src="https://x3dom.org/release/x3dom.js"> </script>
 <!-- <link rel="stylesheet" type="text/css" href="http://x3dom.org/release/x3dom.css" /> -->
 
 {% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Fix an issue where the x3dom code couldn't be loaded in the live/public version of the RTD build. This was caused by writing the url to the x3dom code with http instead of https. This issue is documented [here](https://stackoverflow.com/questions/18251128/why-am-i-suddenly-getting-a-blocked-loading-mixed-active-content-issue-in-fire) and you can verify it by clicking on the lock symbol in your status bar and clicking "disable protections for this site" - suddenly the models render properly!

## Motivation and Context
I want docs to work plz thx

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [x] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.rst) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
