### PR TITLE
Add edge methods to Polygon and ConvexPolygon

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -5,6 +5,11 @@ This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html
 v0.x.x - 20xx-xx-xx
 -------------------
 
+Added
+~~~~~
+
+- ``edges``, ``edge_vectors``, and ``edge_lengths`` properties to ``Polygon``
+
 v0.10.0 - 2025-02-24
 -------------------
 

--- a/coxeter/shapes/polygon.py
+++ b/coxeter/shapes/polygon.py
@@ -571,16 +571,10 @@ class Polygon(Shape2D):
         # additional constraint that the circumcircle must lie in the plane of
         # the polygon.
         points = np.concatenate(
-            (
-                self.vertices[1:] - self.vertices[0],
-                self.normal[np.newaxis],
-            )
+            (self.vertices[1:] - self.vertices[0], self.normal[np.newaxis])
         )
         half_point_lengths = np.concatenate(
-            (
-                np.sum(points[:-1] * points[:-1], axis=1) / 2,
-                [0],
-            )
+            (np.sum(points[:-1] * points[:-1], axis=1) / 2, [0])
         )
         x, resids, _, _ = np.linalg.lstsq(points, half_point_lengths, None)
         if len(self.vertices) > 3 and not np.isclose(resids, 0):

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -634,4 +634,10 @@ def test_edge_vectors(poly):
 
 @pytest.mark.parametrize("poly", regular_polygons())
 def test_edge_lengths(poly):
-    np.testing.assert_allclose(poly.edge_lengths, 1.0)
+    expected_edges = np.array(
+        [(i, (i + 1) % poly.num_vertices) for i in range(poly.num_vertices)]
+    )
+    lengths = np.linalg.norm(
+        np.diff(poly.vertices[expected_edges], axis=1).squeeze(), axis=1
+    )
+    np.testing.assert_allclose(poly.edge_lengths, lengths)

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -612,3 +612,26 @@ def test_to_hoomd(points):
     hoomd_dict = poly.to_hoomd()
     for key, val in zip(dict_keys, dict_vals):
         assert np.allclose(hoomd_dict[key], val), f"{key}"
+
+
+@pytest.mark.parametrize("poly", regular_polygons())
+def test_edges(poly):
+    expected_edges = np.array(
+        [(i, (i + 1) % poly.num_vertices) for i in range(poly.num_vertices)]
+    )
+    np.testing.assert_array_equal(poly.edges, expected_edges)
+
+
+@pytest.mark.parametrize("poly", regular_polygons())
+def test_edge_vectors(poly):
+    expected_edges = np.array(
+        [(i, (i + 1) % poly.num_vertices) for i in range(poly.num_vertices)]
+    )
+    np.testing.assert_array_equal(
+        poly.edge_vectors, np.diff(poly.vertices[expected_edges], axis=1).squeeze()
+    )
+
+
+@pytest.mark.parametrize("poly", regular_polygons())
+def test_edge_lengths(poly):
+    np.testing.assert_allclose(poly.edge_lengths, 1.0)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Computing the edges and edge lengths of polygons is useful for testing shape moves and similar operations. This feature also brings the Polygon class more in line with new functionality in Polyhedron.


## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/master/ChangeLog.rst) and the [credits](https://github.com/glotzerlab/coxeter/blob/master/doc/source/credits.rst).
