### PR TITLE
Add shape checking for ConvexPolyhedron

### DIFF
--- a/coxeter/shapes/convex_polyhedron.py
+++ b/coxeter/shapes/convex_polyhedron.py
@@ -89,7 +89,13 @@ class ConvexPolyhedron(Polyhedron):
 
     def __init__(self, vertices):
         self._vertices = np.array(vertices, dtype=np.float64)
-        self._ndim = self._vertices.shape[1]
+        vertices_shape = self._vertices.shape
+        if len(vertices_shape) != 2 or vertices_shape[-1] != 3:
+            msg = (
+                f"Vertices array has wrong shape: expected (N, 3), got {vertices_shape}"
+            )
+            raise ValueError(msg)
+        self._ndim = vertices_shape[1]
         hull = ConvexHull(self._vertices)
         self._faces_are_convex = True
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Shape of input vertex arrays is now checked for ConvexPolyhedron, raising a ValueError (as in numpy) when the array is not (N,3)

## Motivation and Context
Scipy convex hull would segfault if passed an array with more than two dimensions, leading to confusing behavior. This fix instead provides a nicely formatted error for users.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/coxeter/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/coxeter/blob/main/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/coxeter/blob/main/ChangeLog.rst) and the [credits](https://github.com/glotzerlab/coxeter/blob/main/doc/source/credits.rst).
